### PR TITLE
Update websocket.ts to fix bun refusing connection

### DIFF
--- a/src/tts/websocket.ts
+++ b/src/tts/websocket.ts
@@ -182,6 +182,15 @@ export default class WebSocket extends Client {
 			url.searchParams.set("cartesia_version", CARTESIA_VERSION);
 			return url.toString();
 		});
+		/**
+		* @summary Bun websocket binaryType has a bug where its native WebSocket implementation doesn't accept blob
+		* @summary This is a workaround that is recommended by partykit
+		* @summary you can track the issue here
+		* @link https://github.com/partykit/partykit/issues/774
+		*/
+	    	if (process?.versions?.bun) {
+		    this.socket.binaryType = 'arraybuffer';
+		}
 		this.socket.onopen = () => {
 			this.#isConnected = true;
 			emitter.emit("open");


### PR DESCRIPTION
Hi love the work you and the team has been doing,
Currently the WebSocket cannot run on bun due to the binaryType, to fix it you must update the binaryType manually from blob to arraybuffer.
you can view the issue here: https://github.com/partykit/partykit/issues/774