### PR TITLE
fix: bytes endpoints returns `ArrayBuffer`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -7,3 +7,9 @@ src/index.ts
 
 src/core/websocket
 src/serialization/resources/tts/types/OutputFormat.ts
+
+# arraybuffer
+src/api/resources/tts/client/Client.ts
+src/api/resources/voiceChanger/client/Client.ts
+src/core/fetcher/Fetcher.ts
+src/core/fetcher/getResponseBody.ts

--- a/src/api/resources/tts/client/Client.ts
+++ b/src/api/resources/tts/client/Client.ts
@@ -34,8 +34,8 @@ export declare namespace Tts {
 export class Tts {
     constructor(protected readonly _options: Tts.Options = {}) {}
 
-    public async bytes(request: Cartesia.TtsRequest, requestOptions?: Tts.RequestOptions): Promise<stream.Readable> {
-        const _response = await (this._options.fetcher ?? core.fetcher)<stream.Readable>({
+    public async bytes(request: Cartesia.TtsRequest, requestOptions?: Tts.RequestOptions): Promise<ArrayBuffer> {
+        const _response = await (this._options.fetcher ?? core.fetcher)<ArrayBuffer>({
             url: urlJoin(
                 (await core.Supplier.get(this._options.environment)) ?? environments.CartesiaEnvironment.Production,
                 "/tts/bytes"
@@ -54,7 +54,7 @@ export class Tts {
             contentType: "application/json",
             requestType: "json",
             body: serializers.TtsRequest.jsonOrThrow(request, { unrecognizedObjectKeys: "strip" }),
-            responseType: "streaming",
+            responseType: "arraybuffer",
             timeoutMs: requestOptions?.timeoutInSeconds != null ? requestOptions.timeoutInSeconds * 1000 : 60000,
             maxRetries: requestOptions?.maxRetries,
             abortSignal: requestOptions?.abortSignal,

--- a/src/api/resources/voiceChanger/client/Client.ts
+++ b/src/api/resources/voiceChanger/client/Client.ts
@@ -45,7 +45,7 @@ export class VoiceChanger {
         clip: File | fs.ReadStream | Blob,
         request: Cartesia.VoiceChangerBytesRequest,
         requestOptions?: VoiceChanger.RequestOptions
-    ): Promise<stream.Readable> {
+    ): Promise<ArrayBuffer> {
         const _request = await core.newFormData();
         await _request.appendFile("clip", clip);
         await _request.append("voice[id]", request.voiceId);
@@ -60,7 +60,7 @@ export class VoiceChanger {
         }
 
         const _maybeEncodedRequest = await _request.getRequest();
-        const _response = await (this._options.fetcher ?? core.fetcher)<stream.Readable>({
+        const _response = await (this._options.fetcher ?? core.fetcher)<ArrayBuffer>({
             url: urlJoin(
                 (await core.Supplier.get(this._options.environment)) ?? environments.CartesiaEnvironment.Production,
                 "/voice-changer/bytes"
@@ -80,7 +80,7 @@ export class VoiceChanger {
             requestType: "file",
             duplex: _maybeEncodedRequest.duplex,
             body: _maybeEncodedRequest.body,
-            responseType: "streaming",
+            responseType: "arraybuffer",
             timeoutMs: requestOptions?.timeoutInSeconds != null ? requestOptions.timeoutInSeconds * 1000 : 60000,
             maxRetries: requestOptions?.maxRetries,
             abortSignal: requestOptions?.abortSignal,

--- a/src/core/fetcher/Fetcher.ts
+++ b/src/core/fetcher/Fetcher.ts
@@ -21,7 +21,7 @@ export declare namespace Fetcher {
         withCredentials?: boolean;
         abortSignal?: AbortSignal;
         requestType?: "json" | "file" | "bytes";
-        responseType?: "json" | "blob" | "sse" | "streaming" | "text";
+        responseType?: "json" | "blob" | "sse" | "streaming" | "text" | "arraybuffer";
         duplex?: "half";
     }
 

--- a/src/core/fetcher/getResponseBody.ts
+++ b/src/core/fetcher/getResponseBody.ts
@@ -7,6 +7,8 @@ export async function getResponseBody(response: Response, responseType?: string)
         return response.body;
     } else if (response.body != null && responseType === "streaming") {
         return chooseStreamWrapper(response.body);
+    } else if (response.body != null && responseType === "arraybuffer") {
+        return await response.arrayBuffer();
     } else if (response.body != null && responseType === "text") {
         return await response.text();
     } else {


### PR DESCRIPTION
This PR illustrates the change to the client to return an `ArrayBuffer`. 