### PR TITLE
docs: clarify required bufferDuration parameter in WebPlayer constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ import { WebPlayer } from "@cartesia/cartesia-js";
 console.log("Playing stream...");
 
 // Create a Player object.
-const player = new WebPlayer();
+const player = new WebPlayer({ bufferDuration: 200 }); // Set buffer duration (in milliseconds) as needed.
+
 
 // Play the audio. (`response` includes a custom Source object that the Player can play.)
 // The call resolves when the audio finishes playing.


### PR DESCRIPTION
This change ensures that the user is aware that the bufferDuration is a required parameter when creating a WebPlayer instance, and also provides an example value for it.

what does the number value represents seconds or milliseconds, I have assumed milliseconds for now?