### PR TITLE
Use WebSocket.binaryType "arraybuffer" for Bun runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cartesia/cartesia-js",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "private": false,
     "repository": "https://github.com/cartesia-ai/cartesia-js",
     "main": "./index.js",

--- a/src/wrapper/Websocket.ts
+++ b/src/wrapper/Websocket.ts
@@ -18,6 +18,7 @@ import {
 import { Tts } from "../api/resources/tts/client/Client";
 import Source from "./source";
 import qs from "qs";
+import { RUNTIME } from "../core";
 
 export default class Websocket {
     socket?: ReconnectingWebSocket;
@@ -194,6 +195,12 @@ export default class Websocket {
             undefined,
             options
         );
+
+        // bun doesn't support the default `blob` binaryType
+        if (RUNTIME.type === "bun") {
+            this.socket.binaryType = "arraybuffer";
+        }
+
         this.socket!.reconnect();
 
         this.socket!.onopen = () => {


### PR DESCRIPTION
I verified this works by writing the output to the process output, and play it with sox.
```js
import { CartesiaClient } from "@cartesia/cartesia-js";

const cartesia = new CartesiaClient({
    apiKey: process.env.CARTESIA_API_KEY,
});

// Initialize the WebSocket. Make sure the output format you specify is supported.
const websocket = cartesia.tts.websocket({
    container: "raw",
    encoding: "pcm_f32le",
    sampleRate: 44100,
});

try {
    await websocket.connect();
} catch (error) {
    console.error(`Failed to connect to Cartesia: ${error}`);
    throw error;
}

// Create a stream.
const response = await websocket.send({
    modelId: "sonic-english",
    voice: {
        mode: "id",
        id: "a0e99841-438c-4a64-b679-ae501e7d6091",
    },
    transcript: "Hello, world!",
    // The WebSocket sets output_format on your behalf.
});

// You can also access messages using a for-await-of loop.
for await (const message of response.events("message")) {
  var json = JSON.parse(message);
  if(json.data) {
    const binaryData = Buffer.from(json.data, 'base64');
    process.stdout.write(binaryData);
  }
}
```

```bash
bun index.mjs | play -t raw --endian little -e floating-point -b 32 -c 1 -r 44100  -
```