### PR TITLE
feat: strongly type error responses for API and websocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ dist-deno
 /*.tgz
 .idea/
 .eslintcache
-
+.vscode

--- a/examples/browser_examples.ts
+++ b/examples/browser_examples.ts
@@ -92,11 +92,7 @@ async function ttsWebsocketStreamAudio(client: Cartesia): Promise<void> {
   })) {
     if (event.type === 'chunk' && event.audio) {
       // event.audio is a raw buffer of f32le samples
-      const floats = new Float32Array(
-        event.audio.buffer,
-        event.audio.byteOffset,
-        event.audio.byteLength / 4,
-      );
+      const floats = new Float32Array(event.audio.buffer, event.audio.byteOffset, event.audio.byteLength / 4);
       chunks.push(floats);
     }
   }
@@ -139,11 +135,7 @@ async function ttsWebsocketLowLatency(client: Cartesia): Promise<void> {
     output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: sampleRate },
   })) {
     if (event.type === 'chunk' && event.audio) {
-      const floats = new Float32Array(
-        event.audio.buffer,
-        event.audio.byteOffset,
-        event.audio.byteLength / 4,
-      );
+      const floats = new Float32Array(event.audio.buffer, event.audio.byteOffset, event.audio.byteLength / 4);
 
       const audioBuffer = audioCtx.createBuffer(1, floats.length, sampleRate);
       audioBuffer.getChannelData(0).set(floats);

--- a/examples/nextjs/app/api/token/route.ts
+++ b/examples/nextjs/app/api/token/route.ts
@@ -1,6 +1,6 @@
-import Cartesia from "@cartesia/cartesia-js";
+import Cartesia from '@cartesia/cartesia-js';
 
-const client = new Cartesia({ apiKey: process.env.CARTESIA_API_KEY });
+const client = new Cartesia({ apiKey: process.env['CARTESIA_API_KEY'] });
 
 export async function POST() {
   const { token } = await client.accessToken.create({

--- a/src/backcompat/errors.ts
+++ b/src/backcompat/errors.ts
@@ -1,3 +1,5 @@
+import { APIConnectionTimeoutError, APIError } from '../core/error';
+
 /** @deprecated Use {@link CartesiaError} or specialized error classes from core/error instead. */
 export class CartesiaClientError extends Error {
   readonly statusCode?: number;
@@ -20,5 +22,23 @@ export class CartesiaTimeoutError extends Error {
   constructor(message: string) {
     super(message);
     Object.setPrototypeOf(this, CartesiaTimeoutError.prototype);
+  }
+}
+
+export async function wrap<T>(promise: Promise<T>): Promise<T> {
+  try {
+    return await promise;
+  } catch (e) {
+    if (e instanceof APIConnectionTimeoutError) {
+      throw new CartesiaTimeoutError(e.message);
+    }
+    if (e instanceof APIError) {
+      throw new CartesiaClientError({
+        message: e.message,
+        statusCode: e.status,
+        body: e.details,
+      });
+    }
+    throw e;
   }
 }

--- a/src/backcompat/errors.ts
+++ b/src/backcompat/errors.ts
@@ -1,5 +1,3 @@
-import { APIConnectionTimeoutError, APIError } from '../core/error';
-
 /** @deprecated Use {@link CartesiaError} or specialized error classes from core/error instead. */
 export class CartesiaClientError extends Error {
   readonly statusCode?: number;
@@ -22,23 +20,5 @@ export class CartesiaTimeoutError extends Error {
   constructor(message: string) {
     super(message);
     Object.setPrototypeOf(this, CartesiaTimeoutError.prototype);
-  }
-}
-
-export async function wrap<T>(promise: Promise<T>): Promise<T> {
-  try {
-    return await promise;
-  } catch (e) {
-    if (e instanceof APIConnectionTimeoutError) {
-      throw new CartesiaTimeoutError(e.message);
-    }
-    if (e instanceof APIError) {
-      throw new CartesiaClientError({
-        message: e.message,
-        statusCode: e.status,
-        body: e.details,
-      });
-    }
-    throw e;
   }
 }

--- a/src/backcompat/tts-wrapper.ts
+++ b/src/backcompat/tts-wrapper.ts
@@ -387,7 +387,7 @@ export class TTSWrapper {
       throw new Error('Response body is null');
     }
 
-    return Readable.fromWeb(response.body);
+    return Readable.fromWeb(response.body as any);
   }
 
   /** @deprecated Use {@link Cartesia.tts.generate} instead. */
@@ -429,6 +429,6 @@ export class TTSWrapper {
       throw new Error('Response body is null');
     }
 
-    return Readable.fromWeb(response.body);
+    return Readable.fromWeb(response.body as any);
   }
 }

--- a/src/backcompat/utils.ts
+++ b/src/backcompat/utils.ts
@@ -26,7 +26,7 @@ export async function wrap<T, R = T>(promise: Promise<T>): Promise<R> {
       throw new CartesiaClientError({
         message: e.message,
         statusCode: e.status,
-        body: e.error,
+        body: e.details,
       });
     }
     throw e;

--- a/src/client.ts
+++ b/src/client.ts
@@ -632,6 +632,7 @@ export class Cartesia {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -631,6 +631,7 @@ export class Cartesia {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -632,7 +632,6 @@ export class Cartesia {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
-      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -332,7 +332,7 @@ export class Cartesia {
 
   protected makeStatusError(
     status: number,
-    error: Errors.APIErrorPayload | undefined,
+    error: Errors.APIErrorPayload,
     message: string | undefined,
     headers: Headers,
   ): Errors.APIError {
@@ -542,7 +542,6 @@ export class Cartesia {
 
       const errText = await response.text().catch((err: any) => castToError(err).message);
       const errJSON = Errors.safeAPIErrorPayload(safeJSON(errText));
-      const errMessage = errJSON ? undefined : errText;
 
       loggerFor(this).debug(
         `[${requestLogID}] response error (${retryMessage})`,
@@ -551,12 +550,12 @@ export class Cartesia {
           url: response.url,
           status: response.status,
           headers: response.headers,
-          message: errMessage,
+          message: errJSON.message,
           durationMs: Date.now() - startTime,
         }),
       );
 
-      const err = this.makeStatusError(response.status, errJSON, errMessage, response.headers);
+      const err = this.makeStatusError(response.status, errJSON, errJSON.message, response.headers);
       throw err;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -332,7 +332,7 @@ export class Cartesia {
 
   protected makeStatusError(
     status: number,
-    error: Object,
+    error: Errors.APIErrorPayload | undefined,
     message: string | undefined,
     headers: Headers,
   ): Errors.APIError {
@@ -541,7 +541,7 @@ export class Cartesia {
       loggerFor(this).info(`${responseInfo} - ${retryMessage}`);
 
       const errText = await response.text().catch((err: any) => castToError(err).message);
-      const errJSON = safeJSON(errText) as any;
+      const errJSON = Errors.safeAPIErrorPayload(safeJSON(errText));
       const errMessage = errJSON ? undefined : errText;
 
       loggerFor(this).debug(

--- a/src/client.ts
+++ b/src/client.ts
@@ -631,7 +631,6 @@ export class Cartesia {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
-      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -9,15 +9,16 @@ export type BadRequestErrorCode =
   | 'file_too_large'
   | 'voice_model_mismatch'
   | 'unsupported_audio_format'
-  | 'language_not_supported';
+  | 'language_not_supported'
+  | (string & {});
 
-export type PaymentRequiredErrorCode = 'quota_exceeded' | 'plan_upgrade_required';
+export type PaymentRequiredErrorCode = 'quota_exceeded' | 'plan_upgrade_required' | (string & {});
 
-export type NotFoundErrorCode = 'voice_not_found' | 'model_not_found';
+export type NotFoundErrorCode = 'voice_not_found' | 'model_not_found' | (string & {});
 
-export type RateLimitErrorCode = 'concurrency_limited';
+export type RateLimitErrorCode = 'concurrency_limited' | (string & {});
 
-export type ContentTooLargeErrorCode = 'file_too_large';
+export type ContentTooLargeErrorCode = 'file_too_large' | (string & {});
 
 // Union of all error codes
 export type APIErrorCode =

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -34,7 +34,7 @@ export type APIErrorPayload<TErrorCode extends APIErrorCode = APIErrorCode> = {
   title: string;
   error_code: TErrorCode | undefined;
   doc_url: string | undefined;
-  raw?: APIErrorRaw;
+  raw: APIErrorRaw;
 };
 
 export type APIErrorRaw = Record<string, unknown> | string;
@@ -102,6 +102,7 @@ const DEFAULT_ERROR_PAYLOAD: APIErrorPayload = {
   title: 'Unknown error',
   error_code: undefined,
   doc_url: undefined,
+  raw: 'unknown',
 };
 
 export function safeAPIErrorPayload(response: unknown): APIErrorPayload {
@@ -140,31 +141,31 @@ export class APIError<
   /** HTTP headers for the response that caused the error */
   readonly headers: THeaders;
   /** JSON body of the response that caused the error */
-  readonly error: APIErrorPayloadFor<TErrorCode>;
+  readonly details: APIErrorPayloadFor<TErrorCode>;
 
   constructor(
     status: TStatus,
-    error: APIErrorPayloadFor<TErrorCode>,
+    details: APIErrorPayloadFor<TErrorCode>,
     message: string | undefined,
     headers: THeaders,
   ) {
-    super(`${APIError.makeMessage(status, error, message)}`);
+    super(`${APIError.makeMessage(status, details, message)}`);
     this.status = status;
     this.headers = headers;
-    this.error = error;
+    this.details = details;
   }
 
   private static makeMessage(
     status: number | undefined,
-    error: APIErrorPayload | undefined,
+    details: APIErrorPayload | undefined,
     message: string | undefined,
   ) {
     const msg =
-      error?.message ?
-        typeof error.message === 'string' ?
-          error.message
-        : JSON.stringify(error.message)
-      : error ? JSON.stringify(error)
+      details?.message ?
+        typeof details.message === 'string' ?
+          details.message
+        : JSON.stringify(details.message)
+      : details ? JSON.stringify(details)
       : message;
 
     if (status && msg) {

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -1,9 +1,12 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { castToError } from '../internal/errors';
-import { isObj } from '../internal/utils';
 
 export class CartesiaError extends Error {}
+
+const isObj = (obj: unknown): obj is Record<string, unknown> => {
+  return obj != null && typeof obj === 'object' && !Array.isArray(obj);
+};
 
 export type BadRequestErrorCode =
   | 'file_too_large'

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -28,7 +28,7 @@ export type APIErrorCode =
   | RateLimitErrorCode
   | ContentTooLargeErrorCode;
 
-export type APIErrorPayload<TErrorCode extends APIErrorCode = APIErrorCode> = {
+export type APIErrorPayload<TErrorCode extends string = string> = {
   request_id: string;
   message: string;
   title: string;
@@ -39,7 +39,7 @@ export type APIErrorPayload<TErrorCode extends APIErrorCode = APIErrorCode> = {
 
 export type APIErrorRaw = Record<string, unknown> | string;
 
-type APIErrorPayloadFor<TErrorCode extends APIErrorCode | never> =
+type APIErrorPayloadFor<TErrorCode extends string | never> =
   [TErrorCode] extends [never] ? undefined : APIErrorPayload<TErrorCode> | undefined;
 
 const DEFAULT_ERROR_PAYLOAD: APIErrorPayload = {
@@ -80,7 +80,7 @@ export function safeAPIErrorPayload(response: unknown): APIErrorPayload {
 export class APIError<
   TStatus extends number | undefined = number | undefined,
   THeaders extends Headers | undefined = Headers | undefined,
-  TErrorCode extends APIErrorCode | never = APIErrorCode,
+  TErrorCode extends string | never = string,
 > extends CartesiaError {
   /** HTTP status for the response that caused the error */
   readonly status: TStatus;
@@ -137,12 +137,7 @@ export class APIError<
     }
 
     if (status === 400) {
-      return new BadRequestError(
-        status,
-        errorPayload as APIErrorPayload<BadRequestErrorCode>,
-        message,
-        headers,
-      );
+      return new BadRequestError(status, errorPayload, message, headers);
     }
 
     if (status === 401) {
@@ -150,12 +145,7 @@ export class APIError<
     }
 
     if (status === 402) {
-      return new PaymentRequiredError(
-        status,
-        errorPayload as APIErrorPayload<PaymentRequiredErrorCode>,
-        message,
-        headers,
-      );
+      return new PaymentRequiredError(status, errorPayload, message, headers);
     }
 
     if (status === 403) {
@@ -163,7 +153,7 @@ export class APIError<
     }
 
     if (status === 404) {
-      return new NotFoundError(status, errorPayload as APIErrorPayload<NotFoundErrorCode>, message, headers);
+      return new NotFoundError(status, errorPayload, message, headers);
     }
 
     if (status === 409) {
@@ -171,12 +161,7 @@ export class APIError<
     }
 
     if (status === 413) {
-      return new ContentTooLargeError(
-        status,
-        errorPayload as APIErrorPayload<ContentTooLargeErrorCode>,
-        message,
-        headers,
-      );
+      return new ContentTooLargeError(status, errorPayload, message, headers);
     }
 
     if (status === 422) {
@@ -184,12 +169,7 @@ export class APIError<
     }
 
     if (status === 429) {
-      return new RateLimitError(
-        status,
-        errorPayload as APIErrorPayload<RateLimitErrorCode>,
-        message,
-        headers,
-      );
+      return new RateLimitError(status, errorPayload, message, headers);
     }
 
     if (status >= 500) {

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -33,10 +33,69 @@ export type APIErrorPayload<TErrorCode extends APIErrorCode | undefined = APIErr
   title: string;
   error_code: TErrorCode | undefined;
   doc_url: string | undefined;
+  raw: Record<string, unknown>;
 };
+
+const BAD_REQUEST_ERROR_CODES = {
+  file_too_large: true,
+  voice_model_mismatch: true,
+  unsupported_audio_format: true,
+  language_not_supported: true,
+} as const satisfies Record<BadRequestErrorCode, true>;
+
+const PAYMENT_REQUIRED_ERROR_CODES = {
+  quota_exceeded: true,
+  plan_upgrade_required: true,
+} as const satisfies Record<PaymentRequiredErrorCode, true>;
+
+const NOT_FOUND_ERROR_CODES = {
+  voice_not_found: true,
+  model_not_found: true,
+} as const satisfies Record<NotFoundErrorCode, true>;
+
+const RATE_LIMIT_ERROR_CODES = {
+  concurrency_limited: true,
+} as const satisfies Record<RateLimitErrorCode, true>;
+
+const CONTENT_TOO_LARGE_ERROR_CODES = {
+  file_too_large: true,
+} as const satisfies Record<ContentTooLargeErrorCode, true>;
+
+const API_ERROR_CODES = {
+  ...BAD_REQUEST_ERROR_CODES,
+  ...PAYMENT_REQUIRED_ERROR_CODES,
+  ...NOT_FOUND_ERROR_CODES,
+  ...RATE_LIMIT_ERROR_CODES,
+  ...CONTENT_TOO_LARGE_ERROR_CODES,
+} as const satisfies Record<APIErrorCode, true>;
+
+function isAPIErrorCode(errorCode: unknown): errorCode is APIErrorCode {
+  return typeof errorCode === 'string' && errorCode in API_ERROR_CODES;
+}
+
+function isAPIErrorPayloadForCodes<TErrorCode extends APIErrorCode>(
+  payload: APIErrorPayload | undefined,
+  codes: Readonly<Record<TErrorCode, true>>,
+): payload is APIErrorPayload<TErrorCode> | undefined {
+  return payload === undefined || payload.error_code === undefined || payload.error_code in codes;
+}
+
+function narrowAPIErrorPayload<TErrorCode extends APIErrorCode>(
+  payload: APIErrorPayload | undefined,
+  codes: Readonly<Record<TErrorCode, true>>,
+): APIErrorPayload<TErrorCode> | undefined {
+  if (!payload) {
+    return undefined;
+  }
+  if (isAPIErrorPayloadForCodes(payload, codes)) {
+    return payload;
+  }
+  return { ...payload, error_code: undefined };
+}
 
 export function safeAPIErrorPayload(response: unknown): APIErrorPayload | undefined {
   if (!isObj(response)) return undefined;
+  const raw = response;
   const { request_id, message, title, error_code, doc_url } = response;
   if (typeof request_id !== 'string' || typeof message !== 'string' || typeof title !== 'string') {
     return undefined;
@@ -45,9 +104,9 @@ export function safeAPIErrorPayload(response: unknown): APIErrorPayload | undefi
     request_id,
     message,
     title,
-    // If error_code is a string, assume its a valid APIErrorCode since its coming from the API.
-    error_code: typeof error_code === 'string' ? (error_code as APIErrorCode) : undefined,
+    error_code: isAPIErrorCode(error_code) ? error_code : undefined,
     doc_url: typeof doc_url === 'string' ? doc_url : undefined,
+    raw,
   };
 }
 
@@ -113,7 +172,7 @@ export class APIError<
     if (status === 400) {
       return new BadRequestError(
         status,
-        errorPayload as APIErrorPayload<BadRequestErrorCode>,
+        narrowAPIErrorPayload(errorPayload, BAD_REQUEST_ERROR_CODES),
         message,
         headers,
       );
@@ -126,7 +185,7 @@ export class APIError<
     if (status === 402) {
       return new PaymentRequiredError(
         status,
-        errorPayload as APIErrorPayload<PaymentRequiredErrorCode>,
+        narrowAPIErrorPayload(errorPayload, PAYMENT_REQUIRED_ERROR_CODES),
         message,
         headers,
       );
@@ -137,7 +196,7 @@ export class APIError<
     }
 
     if (status === 404) {
-      return new NotFoundError(status, errorPayload as APIErrorPayload<NotFoundErrorCode>, message, headers);
+      return new NotFoundError(status, narrowAPIErrorPayload(errorPayload, NOT_FOUND_ERROR_CODES), message, headers);
     }
 
     if (status === 409) {
@@ -147,7 +206,7 @@ export class APIError<
     if (status === 413) {
       return new ContentTooLargeError(
         status,
-        errorPayload as APIErrorPayload<ContentTooLargeErrorCode>,
+        narrowAPIErrorPayload(errorPayload, CONTENT_TOO_LARGE_ERROR_CODES),
         message,
         headers,
       );
@@ -160,7 +219,7 @@ export class APIError<
     if (status === 429) {
       return new RateLimitError(
         status,
-        errorPayload as APIErrorPayload<RateLimitErrorCode>,
+        narrowAPIErrorPayload(errorPayload, RATE_LIMIT_ERROR_CODES),
         message,
         headers,
       );

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -42,60 +42,6 @@ export type APIErrorRaw = Record<string, unknown> | string;
 type APIErrorPayloadFor<TErrorCode extends APIErrorCode | never> =
   [TErrorCode] extends [never] ? undefined : APIErrorPayload<TErrorCode> | undefined;
 
-const BAD_REQUEST_ERROR_CODES = {
-  file_too_large: true,
-  voice_model_mismatch: true,
-  unsupported_audio_format: true,
-  language_not_supported: true,
-} as const satisfies Record<BadRequestErrorCode, true>;
-
-const PAYMENT_REQUIRED_ERROR_CODES = {
-  quota_exceeded: true,
-  plan_upgrade_required: true,
-} as const satisfies Record<PaymentRequiredErrorCode, true>;
-
-const NOT_FOUND_ERROR_CODES = {
-  voice_not_found: true,
-  model_not_found: true,
-} as const satisfies Record<NotFoundErrorCode, true>;
-
-const RATE_LIMIT_ERROR_CODES = {
-  concurrency_limited: true,
-} as const satisfies Record<RateLimitErrorCode, true>;
-
-const CONTENT_TOO_LARGE_ERROR_CODES = {
-  file_too_large: true,
-} as const satisfies Record<ContentTooLargeErrorCode, true>;
-
-const API_ERROR_CODES = {
-  ...BAD_REQUEST_ERROR_CODES,
-  ...PAYMENT_REQUIRED_ERROR_CODES,
-  ...NOT_FOUND_ERROR_CODES,
-  ...RATE_LIMIT_ERROR_CODES,
-  ...CONTENT_TOO_LARGE_ERROR_CODES,
-} as const satisfies Record<APIErrorCode, true>;
-
-function isAPIErrorCode(errorCode: unknown): errorCode is APIErrorCode {
-  return typeof errorCode === 'string' && errorCode in API_ERROR_CODES;
-}
-
-function isAPIErrorPayloadForCodes<TErrorCode extends APIErrorCode>(
-  payload: APIErrorPayload,
-  codes: Readonly<Record<TErrorCode, true>>,
-): payload is APIErrorPayload<TErrorCode> {
-  return payload.error_code === undefined || payload.error_code in codes;
-}
-
-function narrowAPIErrorPayload<TErrorCode extends APIErrorCode>(
-  payload: APIErrorPayload,
-  codes: Readonly<Record<TErrorCode, true>>,
-): APIErrorPayload<TErrorCode> {
-  if (isAPIErrorPayloadForCodes(payload, codes)) {
-    return payload;
-  }
-  return { ...payload, error_code: undefined };
-}
-
 const DEFAULT_ERROR_PAYLOAD: APIErrorPayload = {
   request_id: 'unknown',
   message: 'Unknown error',
@@ -125,7 +71,7 @@ export function safeAPIErrorPayload(response: unknown): APIErrorPayload {
     request_id,
     message,
     title,
-    error_code: isAPIErrorCode(error_code) ? error_code : undefined,
+    error_code: error_code != null ? String(error_code) : undefined,
     doc_url: typeof doc_url === 'string' ? doc_url : undefined,
     raw,
   };
@@ -193,7 +139,7 @@ export class APIError<
     if (status === 400) {
       return new BadRequestError(
         status,
-        narrowAPIErrorPayload(errorPayload, BAD_REQUEST_ERROR_CODES),
+        errorPayload as APIErrorPayload<BadRequestErrorCode>,
         message,
         headers,
       );
@@ -206,7 +152,7 @@ export class APIError<
     if (status === 402) {
       return new PaymentRequiredError(
         status,
-        narrowAPIErrorPayload(errorPayload, PAYMENT_REQUIRED_ERROR_CODES),
+        errorPayload as APIErrorPayload<PaymentRequiredErrorCode>,
         message,
         headers,
       );
@@ -217,12 +163,7 @@ export class APIError<
     }
 
     if (status === 404) {
-      return new NotFoundError(
-        status,
-        narrowAPIErrorPayload(errorPayload, NOT_FOUND_ERROR_CODES),
-        message,
-        headers,
-      );
+      return new NotFoundError(status, errorPayload as APIErrorPayload<NotFoundErrorCode>, message, headers);
     }
 
     if (status === 409) {
@@ -232,7 +173,7 @@ export class APIError<
     if (status === 413) {
       return new ContentTooLargeError(
         status,
-        narrowAPIErrorPayload(errorPayload, CONTENT_TOO_LARGE_ERROR_CODES),
+        errorPayload as APIErrorPayload<ContentTooLargeErrorCode>,
         message,
         headers,
       );
@@ -245,7 +186,7 @@ export class APIError<
     if (status === 429) {
       return new RateLimitError(
         status,
-        narrowAPIErrorPayload(errorPayload, RATE_LIMIT_ERROR_CODES),
+        errorPayload as APIErrorPayload<RateLimitErrorCode>,
         message,
         headers,
       );

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -196,7 +196,12 @@ export class APIError<
     }
 
     if (status === 404) {
-      return new NotFoundError(status, narrowAPIErrorPayload(errorPayload, NOT_FOUND_ERROR_CODES), message, headers);
+      return new NotFoundError(
+        status,
+        narrowAPIErrorPayload(errorPayload, NOT_FOUND_ERROR_CODES),
+        message,
+        headers,
+      );
     }
 
     if (status === 409) {

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -1,29 +1,85 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { castToError } from '../internal/errors';
+import { isObj } from '../internal/utils';
 
 export class CartesiaError extends Error {}
+
+export type BadRequestErrorCode =
+  | 'file_too_large'
+  | 'voice_model_mismatch'
+  | 'unsupported_audio_format'
+  | 'language_not_supported';
+
+export type PaymentRequiredErrorCode = 'quota_exceeded' | 'plan_upgrade_required';
+
+export type NotFoundErrorCode = 'voice_not_found' | 'model_not_found';
+
+export type RateLimitErrorCode = 'concurrency_limited';
+
+export type ContentTooLargeErrorCode = 'file_too_large';
+
+// Union of all error codes
+export type APIErrorCode =
+  | BadRequestErrorCode
+  | PaymentRequiredErrorCode
+  | NotFoundErrorCode
+  | RateLimitErrorCode
+  | ContentTooLargeErrorCode;
+
+export type APIErrorPayload<TErrorCode extends APIErrorCode | undefined = APIErrorCode | undefined> = {
+  request_id: string;
+  message: string;
+  title: string;
+  error_code: TErrorCode | undefined;
+  doc_url: string | undefined;
+};
+
+export function safeAPIErrorPayload(response: unknown): APIErrorPayload | undefined {
+  if (!isObj(response)) return undefined;
+  const { request_id, message, title, error_code, doc_url } = response;
+  if (typeof request_id !== 'string' || typeof message !== 'string' || typeof title !== 'string') {
+    return undefined;
+  }
+  return {
+    request_id,
+    message,
+    title,
+    // If error_code is a string, assume its a valid APIErrorCode since its coming from the API.
+    error_code: typeof error_code === 'string' ? (error_code as APIErrorCode) : undefined,
+    doc_url: typeof doc_url === 'string' ? doc_url : undefined,
+  };
+}
 
 export class APIError<
   TStatus extends number | undefined = number | undefined,
   THeaders extends Headers | undefined = Headers | undefined,
-  TError extends Object | undefined = Object | undefined,
+  TErrorCode extends APIErrorCode | undefined = APIErrorCode | undefined,
 > extends CartesiaError {
   /** HTTP status for the response that caused the error */
   readonly status: TStatus;
   /** HTTP headers for the response that caused the error */
   readonly headers: THeaders;
   /** JSON body of the response that caused the error */
-  readonly error: TError;
+  readonly error: APIErrorPayload<TErrorCode | undefined> | undefined;
 
-  constructor(status: TStatus, error: TError, message: string | undefined, headers: THeaders) {
+  constructor(
+    status: TStatus,
+    error: APIErrorPayload<TErrorCode> | undefined,
+    message: string | undefined,
+    headers: THeaders,
+  ) {
     super(`${APIError.makeMessage(status, error, message)}`);
     this.status = status;
     this.headers = headers;
     this.error = error;
   }
 
-  private static makeMessage(status: number | undefined, error: any, message: string | undefined) {
+  private static makeMessage(
+    status: number | undefined,
+    error: APIErrorPayload | undefined,
+    message: string | undefined,
+  ) {
     const msg =
       error?.message ?
         typeof error.message === 'string' ?
@@ -46,49 +102,75 @@ export class APIError<
 
   static generate(
     status: number | undefined,
-    errorResponse: Object | undefined,
+    errorPayload: APIErrorPayload | undefined,
     message: string | undefined,
     headers: Headers | undefined,
   ): APIError {
     if (!status || !headers) {
-      return new APIConnectionError({ message, cause: castToError(errorResponse) });
+      return new APIConnectionError({ message, cause: castToError(errorPayload) });
     }
 
-    const error = errorResponse as Record<string, any>;
-
     if (status === 400) {
-      return new BadRequestError(status, error, message, headers);
+      return new BadRequestError(
+        status,
+        errorPayload as APIErrorPayload<BadRequestErrorCode>,
+        message,
+        headers,
+      );
     }
 
     if (status === 401) {
-      return new AuthenticationError(status, error, message, headers);
+      return new AuthenticationError(status, errorPayload, message, headers);
+    }
+
+    if (status === 402) {
+      return new PaymentRequiredError(
+        status,
+        errorPayload as APIErrorPayload<PaymentRequiredErrorCode>,
+        message,
+        headers,
+      );
     }
 
     if (status === 403) {
-      return new PermissionDeniedError(status, error, message, headers);
+      return new PermissionDeniedError(status, errorPayload, message, headers);
     }
 
     if (status === 404) {
-      return new NotFoundError(status, error, message, headers);
+      return new NotFoundError(status, errorPayload as APIErrorPayload<NotFoundErrorCode>, message, headers);
     }
 
     if (status === 409) {
-      return new ConflictError(status, error, message, headers);
+      return new ConflictError(status, errorPayload, message, headers);
+    }
+
+    if (status === 413) {
+      return new ContentTooLargeError(
+        status,
+        errorPayload as APIErrorPayload<ContentTooLargeErrorCode>,
+        message,
+        headers,
+      );
     }
 
     if (status === 422) {
-      return new UnprocessableEntityError(status, error, message, headers);
+      return new UnprocessableEntityError(status, errorPayload, message, headers);
     }
 
     if (status === 429) {
-      return new RateLimitError(status, error, message, headers);
+      return new RateLimitError(
+        status,
+        errorPayload as APIErrorPayload<RateLimitErrorCode>,
+        message,
+        headers,
+      );
     }
 
     if (status >= 500) {
-      return new InternalServerError(status, error, message, headers);
+      return new InternalServerError(status, errorPayload, message, headers);
     }
 
-    return new APIError(status, error, message, headers);
+    return new APIError(status, errorPayload, message, headers);
   }
 }
 
@@ -113,18 +195,22 @@ export class APIConnectionTimeoutError extends APIConnectionError {
   }
 }
 
-export class BadRequestError extends APIError<400, Headers> {}
+export class BadRequestError extends APIError<400, Headers, BadRequestErrorCode> {}
 
 export class AuthenticationError extends APIError<401, Headers> {}
 
+export class PaymentRequiredError extends APIError<402, Headers, PaymentRequiredErrorCode> {}
+
 export class PermissionDeniedError extends APIError<403, Headers> {}
 
-export class NotFoundError extends APIError<404, Headers> {}
+export class NotFoundError extends APIError<404, Headers, NotFoundErrorCode> {}
 
 export class ConflictError extends APIError<409, Headers> {}
 
+export class ContentTooLargeError extends APIError<413, Headers, ContentTooLargeErrorCode> {}
+
 export class UnprocessableEntityError extends APIError<422, Headers> {}
 
-export class RateLimitError extends APIError<429, Headers> {}
+export class RateLimitError extends APIError<429, Headers, RateLimitErrorCode> {}
 
 export class InternalServerError extends APIError<number, Headers> {}

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -27,14 +27,19 @@ export type APIErrorCode =
   | RateLimitErrorCode
   | ContentTooLargeErrorCode;
 
-export type APIErrorPayload<TErrorCode extends APIErrorCode | undefined = APIErrorCode | undefined> = {
+export type APIErrorPayload<TErrorCode extends APIErrorCode = APIErrorCode> = {
   request_id: string;
   message: string;
   title: string;
   error_code: TErrorCode | undefined;
   doc_url: string | undefined;
-  raw: Record<string, unknown>;
+  raw?: APIErrorRaw;
 };
+
+export type APIErrorRaw = Record<string, unknown> | string;
+
+type APIErrorPayloadFor<TErrorCode extends APIErrorCode | never> =
+  [TErrorCode] extends [never] ? undefined : APIErrorPayload<TErrorCode> | undefined;
 
 const BAD_REQUEST_ERROR_CODES = {
   file_too_large: true,
@@ -74,31 +79,45 @@ function isAPIErrorCode(errorCode: unknown): errorCode is APIErrorCode {
 }
 
 function isAPIErrorPayloadForCodes<TErrorCode extends APIErrorCode>(
-  payload: APIErrorPayload | undefined,
+  payload: APIErrorPayload,
   codes: Readonly<Record<TErrorCode, true>>,
-): payload is APIErrorPayload<TErrorCode> | undefined {
-  return payload === undefined || payload.error_code === undefined || payload.error_code in codes;
+): payload is APIErrorPayload<TErrorCode> {
+  return payload.error_code === undefined || payload.error_code in codes;
 }
 
 function narrowAPIErrorPayload<TErrorCode extends APIErrorCode>(
-  payload: APIErrorPayload | undefined,
+  payload: APIErrorPayload,
   codes: Readonly<Record<TErrorCode, true>>,
-): APIErrorPayload<TErrorCode> | undefined {
-  if (!payload) {
-    return undefined;
-  }
+): APIErrorPayload<TErrorCode> {
   if (isAPIErrorPayloadForCodes(payload, codes)) {
     return payload;
   }
   return { ...payload, error_code: undefined };
 }
 
-export function safeAPIErrorPayload(response: unknown): APIErrorPayload | undefined {
-  if (!isObj(response)) return undefined;
+const DEFAULT_ERROR_PAYLOAD: APIErrorPayload = {
+  request_id: 'unknown',
+  message: 'Unknown error',
+  title: 'Unknown error',
+  error_code: undefined,
+  doc_url: undefined,
+};
+
+export function safeAPIErrorPayload(response: unknown): APIErrorPayload {
+  if (!isObj(response))
+    return {
+      ...DEFAULT_ERROR_PAYLOAD,
+      message: String(response),
+      raw: String(response),
+    };
   const raw = response;
   const { request_id, message, title, error_code, doc_url } = response;
   if (typeof request_id !== 'string' || typeof message !== 'string' || typeof title !== 'string') {
-    return undefined;
+    return {
+      ...DEFAULT_ERROR_PAYLOAD,
+      message: String(message),
+      raw: response,
+    };
   }
   return {
     request_id,
@@ -113,18 +132,18 @@ export function safeAPIErrorPayload(response: unknown): APIErrorPayload | undefi
 export class APIError<
   TStatus extends number | undefined = number | undefined,
   THeaders extends Headers | undefined = Headers | undefined,
-  TErrorCode extends APIErrorCode | undefined = APIErrorCode | undefined,
+  TErrorCode extends APIErrorCode | never = APIErrorCode,
 > extends CartesiaError {
   /** HTTP status for the response that caused the error */
   readonly status: TStatus;
   /** HTTP headers for the response that caused the error */
   readonly headers: THeaders;
   /** JSON body of the response that caused the error */
-  readonly error: APIErrorPayload<TErrorCode | undefined> | undefined;
+  readonly error: APIErrorPayloadFor<TErrorCode>;
 
   constructor(
     status: TStatus,
-    error: APIErrorPayload<TErrorCode> | undefined,
+    error: APIErrorPayloadFor<TErrorCode>,
     message: string | undefined,
     headers: THeaders,
   ) {
@@ -161,7 +180,7 @@ export class APIError<
 
   static generate(
     status: number | undefined,
-    errorPayload: APIErrorPayload | undefined,
+    errorPayload: APIErrorPayload,
     message: string | undefined,
     headers: Headers | undefined,
   ): APIError {
@@ -238,13 +257,13 @@ export class APIError<
   }
 }
 
-export class APIUserAbortError extends APIError<undefined, undefined, undefined> {
+export class APIUserAbortError extends APIError<undefined, undefined, never> {
   constructor({ message }: { message?: string } = {}) {
     super(undefined, undefined, message || 'Request was aborted.', undefined);
   }
 }
 
-export class APIConnectionError extends APIError<undefined, undefined, undefined> {
+export class APIConnectionError extends APIError<undefined, undefined, never> {
   constructor({ message, cause }: { message?: string | undefined; cause?: Error | undefined }) {
     super(undefined, undefined, message || 'Connection error.', undefined);
     // in some environments the 'cause' property is already declared

--- a/src/core/pagination.ts
+++ b/src/core/pagination.ts
@@ -73,9 +73,9 @@ export abstract class AbstractPage<Item> implements AsyncIterable<Item> {
  *    }
  */
 export class PagePromise<
-    PageClass extends AbstractPage<Item>,
-    Item = ReturnType<PageClass['getPaginatedItems']>[number],
-  >
+  PageClass extends AbstractPage<Item>,
+  Item = ReturnType<PageClass['getPaginatedItems']>[number],
+>
   extends APIPromise<PageClass>
   implements AsyncIterable<Item>
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,4 @@ export {
   PermissionDeniedError,
   UnprocessableEntityError,
 } from './core/error';
+export { WebSocketError } from './resources';

--- a/src/internal/detect-platform.ts
+++ b/src/internal/detect-platform.ts
@@ -67,7 +67,7 @@ const getPlatformProperties = (): PlatformProperties => {
       'X-Stainless-Arch': normalizeArch(Deno.build.arch),
       'X-Stainless-Runtime': 'deno',
       'X-Stainless-Runtime-Version':
-        typeof Deno.version === 'string' ? Deno.version : Deno.version?.deno ?? 'unknown',
+        typeof Deno.version === 'string' ? Deno.version : (Deno.version?.deno ?? 'unknown'),
     };
   }
   if (typeof EdgeRuntime !== 'undefined') {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -37,6 +37,7 @@ export {
 export { Stt, type SttTranscribeResponse, type SttTranscribeParams } from './stt';
 export {
   TTS,
+  WebSocketError,
   type GenerationConfig,
   type GenerationRequest,
   type ModelSpeed,

--- a/src/resources/tts/index.ts
+++ b/src/resources/tts/index.ts
@@ -18,3 +18,4 @@ export {
 
 export { TTSWS, TTSWSContext, type ContextOptions, type ContextGenerateRequest } from './ws';
 export { WebSocketTimeoutError } from './internal-base';
+export { WebSocketError } from './internal-base';

--- a/src/resources/tts/internal-base.ts
+++ b/src/resources/tts/internal-base.ts
@@ -66,7 +66,7 @@ export abstract class TTSEmitter extends EventEmitter<WebSocketEvents> {
     message?: string | undefined,
     cause?: any,
   ): void {
-    message = message ?? safeJSONStringify(event) ?? 'unknown error';
+    message = message ?? event?.message ?? 'unknown error';
 
     if (!this._hasListener('error')) {
       const error = new WebSocketError(
@@ -97,12 +97,4 @@ export function buildURL(client: Cartesia, query?: object | null): URL {
   }
   url.protocol = url.protocol === 'http:' ? 'ws:' : 'wss:';
   return url;
-}
-
-function safeJSONStringify(value: unknown): string | null {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return null;
-  }
 }

--- a/src/resources/tts/tts.ts
+++ b/src/resources/tts/tts.ts
@@ -467,6 +467,14 @@ export namespace WebsocketResponse {
      * conversation IDs) as context IDs.
      */
     context_id?: string | null;
+
+    doc_url?: string;
+
+    request_id: string;
+
+    message: string;
+
+    title: string;
   }
 
   export interface PhonemeTimestamps {

--- a/src/resources/tts/tts.ts
+++ b/src/resources/tts/tts.ts
@@ -339,7 +339,7 @@ export namespace WebsocketResponse {
   export interface Chunk {
     data: string;
 
-    /** Decoded audio data as a Buffer. Base64-decodes `data`. Set by the SDK on receipt. 
+    /** Decoded audio data as a Buffer. Base64-decodes `data`. Set by the SDK on receipt.
      * NB: this is a manually-added helper, not auto-generated.
      */
     audio: Buffer | null;

--- a/src/resources/tts/tts.ts
+++ b/src/resources/tts/tts.ts
@@ -343,7 +343,6 @@ export namespace WebsocketResponse {
      * NB: this is a manually-added helper, not auto-generated.
      */
     audio: Buffer | null;
-
     done: boolean;
 
     status_code: number;

--- a/src/resources/tts/tts.ts
+++ b/src/resources/tts/tts.ts
@@ -40,7 +40,7 @@ export class TTS extends APIResource {
    * Returns a promise that resolves when the connection is open.
    */
   async websocket(options?: WS.ClientOptions): Promise<TTSWS> {
-    const ws = new TTSWS(this._client, options);
+    const ws = new TTSWS(this._client, undefined, options);
     return ws.connect();
   }
 

--- a/src/resources/tts/ws.ts
+++ b/src/resources/tts/ws.ts
@@ -37,6 +37,7 @@ interface WebSocketLike {
   close(code?: number, reason?: string): void;
   addEventListener(type: string, listener: (event: any) => void): void;
   removeEventListener(type: string, listener: (event: any) => void): void;
+  emit?(event: string, ...args: any[]): void;
 }
 
 /**
@@ -312,7 +313,7 @@ export class TTSWS extends TTSEmitter {
         // Decode audio for chunk events (mirrors Python SDK's .audio property).
         if (event.type === 'chunk') {
           const chunk = event as TTSAPI.WebsocketResponse.Chunk;
-          chunk.audio = chunk.data ? decodeBase64(chunk.data) as any : null;
+          chunk.audio = chunk.data ? (decodeBase64(chunk.data) as any) : null;
         }
 
         // Always emit on EventEmitter for backwards compatibility and global listeners.

--- a/src/resources/tts/ws.ts
+++ b/src/resources/tts/ws.ts
@@ -170,7 +170,7 @@ export class TTSWSContext {
             return;
           }
           if (event.type === 'error') {
-            throw new Error(JSON.stringify(event));
+            throw new WebSocketError(event.message, event);
           }
         } else {
           // Wait for the next event to be pushed into the queue.
@@ -360,7 +360,7 @@ export class TTSWS extends TTSEmitter {
     request = { ...request, context_id: contextId };
     const queue: TTSAPI.WebsocketResponse[] = [];
     let done = false;
-    let error: Error | null = null;
+    let error: WebSocketError | null = null;
     let resolve: (() => void) | null = null;
 
     const onEvent = (event: TTSAPI.WebsocketResponse) => {
@@ -372,7 +372,7 @@ export class TTSWS extends TTSEmitter {
       if (event.type === 'done' || event.type === 'error') {
         done = true;
         if (event.type === 'error') {
-          error = new Error(JSON.stringify(event));
+          error = new WebSocketError(event.message, event);
         }
       }
       resolve?.();

--- a/src/resources/tts/ws.ts
+++ b/src/resources/tts/ws.ts
@@ -9,7 +9,13 @@ try {
   // Optional — in browsers, we use the native WebSocket API instead.
 }
 import { uuid4 } from '../../internal/utils/uuid';
-import { TTSEmitter, WebSocketTimeoutError, TTSStreamMessage, WebSocketError, buildURL } from './internal-base';
+import {
+  TTSEmitter,
+  WebSocketTimeoutError,
+  TTSStreamMessage,
+  WebSocketError,
+  buildURL,
+} from './internal-base';
 import * as TTSAPI from './tts';
 import type { Cartesia } from '../../client';
 
@@ -27,6 +33,8 @@ function decodeBase64(data: string): Uint8Array {
 }
 
 // WebSocket readyState constants (same in both ws and native WebSocket)
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
 const WS_CLOSING = 2;
 const WS_CLOSED = 3;
 
@@ -250,11 +258,12 @@ export class TTSWS extends TTSEmitter {
     options?: WS.ClientOptions | null | undefined,
   ) {
     super();
+    const socketOptions = options ?? undefined;
     this.client = client;
-    this._wsOptions = options;
+    this._wsOptions = socketOptions;
     this.url = buildURL(client, parameters);
     this._ready = Promise.resolve();
-    this._initSocket(options);
+    this._initSocket(socketOptions);
   }
 
   private _initSocket(options?: WS.ClientOptions | undefined): void {
@@ -553,26 +562,26 @@ export class TTSWS extends TTSEmitter {
     const cleanup = () => {
       this.off('event', onEvent);
       this.off('error', onEmitterError);
-      this.socket.off('open', onOpen);
-      this.socket.off('close', onClose);
+      this.socket.removeEventListener('open', onOpen);
+      this.socket.removeEventListener('close', onClose);
     };
 
     this.on('event', onEvent);
     this.on('error', onEmitterError);
-    this.socket.on('open', onOpen);
-    this.socket.on('close', onClose);
+    this.socket.addEventListener('open', onOpen);
+    this.socket.addEventListener('close', onClose);
 
     switch (this.socket.readyState) {
-      case WS.WebSocket.CONNECTING:
+      case WS_CONNECTING:
         push({ type: 'connecting' });
         break;
-      case WS.WebSocket.OPEN:
+      case WS_OPEN:
         push({ type: 'open' });
         break;
-      case WS.WebSocket.CLOSING:
+      case WS_CLOSING:
         push({ type: 'closing' });
         break;
-      case WS.WebSocket.CLOSED:
+      case WS_CLOSED:
         push({ type: 'close' });
         done = true;
         cleanup();

--- a/tests/api-resources/tts.test.ts
+++ b/tests/api-resources/tts.test.ts
@@ -77,16 +77,4 @@ describe('resource tts', () => {
       use_normalized_timestamps: true,
     });
   });
-
-  // Prism tests are disabled
-  test.skip('infill', async () => {
-    const responsePromise = client.tts.infill({});
-    const rawResponse = await responsePromise.asResponse();
-    expect(rawResponse).toBeInstanceOf(Response);
-    const response = await responsePromise;
-    expect(response).not.toBeInstanceOf(Response);
-    const dataAndResponse = await responsePromise.withResponse();
-    expect(dataAndResponse.data).toBe(response);
-    expect(dataAndResponse.response).toBe(rawResponse);
-  });
 });

--- a/tests/api-resources/tts.test.ts
+++ b/tests/api-resources/tts.test.ts
@@ -77,4 +77,16 @@ describe('resource tts', () => {
       use_normalized_timestamps: true,
     });
   });
+
+  // Prism tests are disabled
+  test.skip('infill', async () => {
+    const responsePromise = client.tts.infill({});
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
 });

--- a/tests/core/errors.test.ts
+++ b/tests/core/errors.test.ts
@@ -12,10 +12,10 @@ describe('safeAPIErrorPayload', () => {
       { request_id: '123', message: 'test', title: 'test' },
       { request_id: '123', message: 'test', title: 'test', error_code: undefined, doc_url: undefined },
     ],
-    // Unknown error code is dropped
+    // Unknown error code is kept
     [
       { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: undefined },
-      { request_id: '123', message: 'test', title: 'test', error_code: undefined, doc_url: undefined },
+      { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: undefined },
     ],
     // Missing required field message falls back to default payload and stringifies message
     [
@@ -96,7 +96,7 @@ describe('APIError.generate', () => {
     expect(error.details?.error_code).toBe('voice_model_mismatch');
   });
 
-  it('drops mismatched status-specific error_code but keeps payload content', () => {
+  it('keeps mismatched status-specific error_code', () => {
     const payload = safeAPIErrorPayload({
       request_id: '123',
       message: 'test',
@@ -112,7 +112,7 @@ describe('APIError.generate', () => {
       request_id: '123',
       message: 'test',
       title: 'test',
-      error_code: undefined,
+      error_code: 'quota_exceeded',
       doc_url: 'test',
       raw: payload.raw,
     });

--- a/tests/core/errors.test.ts
+++ b/tests/core/errors.test.ts
@@ -1,35 +1,88 @@
-import { safeAPIErrorPayload } from "../../src/core/error";
+import { APIError, BadRequestError, safeAPIErrorPayload } from '../../src/core/error';
 
 describe('safeAPIErrorPayload', () => {
-    for (const [input, expected] of [
-        // Happy path
-        [
-            { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'test' },
-            { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'test' }
-        ],
-        // Only required fields
-        [
-            { request_id: '123', message: 'test', title: 'test' },
-            { request_id: '123', message: 'test', title: 'test', error_code: undefined, doc_url: undefined }
-        ],
-        // Missing required field message
-        [
-            { request_id: '123', title: 'test', error_code: 'test', doc_url: undefined },
-            undefined
-        ],
-        // Required field message wrong type
-        [
-            { request_id: '123', message: 123, title: 'test', error_code: 'test', doc_url: null },
-            undefined
-        ],
-        // Optional field doc_url wrong type
-        [
-            { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: 123 },
-            { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: undefined },
-        ],
-    ]) {
-        it(`${JSON.stringify(input)} -> ${expected}`, () => {
-            expect(safeAPIErrorPayload(input)).toEqual(expected);
-        });
-    }
-})
+  for (const [input, expected] of [
+    // Happy path
+    [
+      { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'test' },
+      { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'test' },
+    ],
+    // Only required fields
+    [
+      { request_id: '123', message: 'test', title: 'test' },
+      { request_id: '123', message: 'test', title: 'test', error_code: undefined, doc_url: undefined },
+    ],
+    // Unknown error code is dropped
+    [
+      { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: undefined },
+      { request_id: '123', message: 'test', title: 'test', error_code: undefined, doc_url: undefined },
+    ],
+    // Missing required field message
+    [{ request_id: '123', title: 'test', error_code: 'test', doc_url: undefined }, undefined],
+    // Required field message wrong type
+    [{ request_id: '123', message: 123, title: 'test', error_code: 'test', doc_url: null }, undefined],
+    // Optional field doc_url wrong type
+    [
+      { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 123 },
+      { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: undefined },
+    ],
+  ]) {
+    it(`${JSON.stringify(input)} -> ${expected}`, () => {
+      if (expected === undefined) {
+        expect(safeAPIErrorPayload(input)).toEqual(undefined);
+        return;
+      }
+
+      expect(safeAPIErrorPayload(input)).toEqual({
+        ...expected,
+        raw: input,
+      });
+    });
+  }
+
+  it('keeps raw as an object reference (not a deep copy)', () => {
+    const input = { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'x' };
+    const payload = safeAPIErrorPayload(input);
+
+    expect(payload?.raw).toBe(input);
+  });
+});
+
+describe('APIError.generate', () => {
+  it('preserves matching status-specific error_code', () => {
+    const payload = safeAPIErrorPayload({
+      request_id: '123',
+      message: 'test',
+      title: 'test',
+      error_code: 'voice_model_mismatch',
+      doc_url: 'test',
+    })!;
+
+    const error = APIError.generate(400, payload, undefined, new Headers());
+
+    expect(error).toBeInstanceOf(BadRequestError);
+    expect(error.error?.error_code).toBe('voice_model_mismatch');
+  });
+
+  it('drops mismatched status-specific error_code but keeps payload content', () => {
+    const payload = safeAPIErrorPayload({
+      request_id: '123',
+      message: 'test',
+      title: 'test',
+      error_code: 'quota_exceeded',
+      doc_url: 'test',
+    })!;
+
+    const error = APIError.generate(400, payload, undefined, new Headers());
+
+    expect(error).toBeInstanceOf(BadRequestError);
+    expect(error.error).toEqual({
+      request_id: '123',
+      message: 'test',
+      title: 'test',
+      error_code: undefined,
+      doc_url: 'test',
+      raw: payload.raw,
+    });
+  });
+});

--- a/tests/core/errors.test.ts
+++ b/tests/core/errors.test.ts
@@ -41,7 +41,13 @@ describe('safeAPIErrorPayload', () => {
   }
 
   it('keeps raw as an object reference (not a deep copy)', () => {
-    const input = { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'x' };
+    const input = {
+      request_id: '123',
+      message: 'test',
+      title: 'test',
+      error_code: 'quota_exceeded',
+      doc_url: 'x',
+    };
     const payload = safeAPIErrorPayload(input);
 
     expect(payload?.raw).toBe(input);

--- a/tests/core/errors.test.ts
+++ b/tests/core/errors.test.ts
@@ -17,26 +17,52 @@ describe('safeAPIErrorPayload', () => {
       { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: undefined },
       { request_id: '123', message: 'test', title: 'test', error_code: undefined, doc_url: undefined },
     ],
-    // Missing required field message
-    [{ request_id: '123', title: 'test', error_code: 'test', doc_url: undefined }, undefined],
-    // Required field message wrong type
-    [{ request_id: '123', message: 123, title: 'test', error_code: 'test', doc_url: null }, undefined],
+    // Missing required field message falls back to default payload and stringifies message
+    [
+      { request_id: '123', title: 'test', error_code: 'test', doc_url: undefined },
+      {
+        request_id: 'unknown',
+        message: 'undefined',
+        title: 'Unknown error',
+        error_code: undefined,
+        doc_url: undefined,
+      },
+    ],
+    // Required field message wrong type falls back to default payload and stringifies message
+    [
+      { request_id: '123', message: 123, title: 'test', error_code: 'test', doc_url: null },
+      {
+        request_id: 'unknown',
+        message: '123',
+        title: 'Unknown error',
+        error_code: undefined,
+        doc_url: undefined,
+      },
+    ],
     // Optional field doc_url wrong type
     [
       { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 123 },
       { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: undefined },
     ],
-  ]) {
-    it(`${JSON.stringify(input)} -> ${expected}`, () => {
-      if (expected === undefined) {
-        expect(safeAPIErrorPayload(input)).toEqual(undefined);
-        return;
-      }
-
-      expect(safeAPIErrorPayload(input)).toEqual({
+    // Non-object payload falls back to default payload and stringifies response
+    [
+      'Unexpected string response',
+      {
+        request_id: 'unknown',
+        message: 'Unexpected string response',
+        title: 'Unknown error',
+        error_code: undefined,
+        doc_url: undefined,
+      },
+    ],
+  ] as const) {
+    it(`${JSON.stringify(input)}`, () => {
+      const payload = safeAPIErrorPayload(input);
+      expect(payload).toEqual({
         ...expected,
         raw: input,
       });
+      expect(payload.raw).toBeTruthy();
     });
   }
 

--- a/tests/core/errors.test.ts
+++ b/tests/core/errors.test.ts
@@ -1,0 +1,35 @@
+import { safeAPIErrorPayload } from "../../src/core/error";
+
+describe('safeAPIErrorPayload', () => {
+    for (const [input, expected] of [
+        // Happy path
+        [
+            { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'test' },
+            { request_id: '123', message: 'test', title: 'test', error_code: 'quota_exceeded', doc_url: 'test' }
+        ],
+        // Only required fields
+        [
+            { request_id: '123', message: 'test', title: 'test' },
+            { request_id: '123', message: 'test', title: 'test', error_code: undefined, doc_url: undefined }
+        ],
+        // Missing required field message
+        [
+            { request_id: '123', title: 'test', error_code: 'test', doc_url: undefined },
+            undefined
+        ],
+        // Required field message wrong type
+        [
+            { request_id: '123', message: 123, title: 'test', error_code: 'test', doc_url: null },
+            undefined
+        ],
+        // Optional field doc_url wrong type
+        [
+            { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: 123 },
+            { request_id: '123', message: 'test', title: 'test', error_code: 'test', doc_url: undefined },
+        ],
+    ]) {
+        it(`${JSON.stringify(input)} -> ${expected}`, () => {
+            expect(safeAPIErrorPayload(input)).toEqual(expected);
+        });
+    }
+})

--- a/tests/core/errors.test.ts
+++ b/tests/core/errors.test.ts
@@ -93,7 +93,7 @@ describe('APIError.generate', () => {
     const error = APIError.generate(400, payload, undefined, new Headers());
 
     expect(error).toBeInstanceOf(BadRequestError);
-    expect(error.error?.error_code).toBe('voice_model_mismatch');
+    expect(error.details?.error_code).toBe('voice_model_mismatch');
   });
 
   it('drops mismatched status-specific error_code but keeps payload content', () => {
@@ -108,7 +108,7 @@ describe('APIError.generate', () => {
     const error = APIError.generate(400, payload, undefined, new Headers());
 
     expect(error).toBeInstanceOf(BadRequestError);
-    expect(error.error).toEqual({
+    expect(error.details).toEqual({
       request_id: '123',
       message: 'test',
       title: 'test',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -538,8 +538,8 @@ describe('retries', () => {
       { signal }: RequestInit = {},
     ): Promise<Response> => {
       if (count++ === 0) {
-        return new Promise(
-          (resolve, reject) => signal?.addEventListener('abort', () => reject(new Error('timed out'))),
+        return new Promise((resolve, reject) =>
+          signal?.addEventListener('abort', () => reject(new Error('timed out'))),
         );
       }
       return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -69,7 +69,7 @@ describe('toFile', () => {
     const result = await toFile(input);
     const file: File = result;
     const blob: Blob = result;
-    void file, blob;
+    (void file, blob);
   });
 });
 

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -67,7 +67,7 @@ describe('toFile', () => {
   it('is assignable to File and Blob', async () => {
     const input = new File(['foo'], 'input.jsonl', { type: 'jsonl' });
     const result = await toFile(input);
-    const file: File = result;
+    const file: import('node:buffer').File = result;
     const blob: Blob = result;
     (void file, blob);
   });

--- a/tests/ws-routing.test.ts
+++ b/tests/ws-routing.test.ts
@@ -37,7 +37,7 @@ function createTestWS(): TTSWS {
 
 /** Simulate a server‑sent message by emitting directly on the socket. */
 function injectEvent(ws: TTSWS, event: Record<string, unknown>) {
-  ws.socket.emit('message', Buffer.from(JSON.stringify(event)), false);
+  (ws.socket as any).emit('message', Buffer.from(JSON.stringify(event)), false);
 }
 
 function makeChunk(contextId: string, seq: number): Record<string, unknown> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "include": ["src", "tests", "examples"],
+  "include": ["src/**/*.ts", "tests/**/*.ts", "examples/**/*.ts"],
   "exclude": [],
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["es2020"],
+    "lib": ["es2020", "dom", "dom.iterable", "dom.asynciterable"],
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
- Adds strong typing for 4xx and 5xx errors, including WebSocket errors. But keeps the error enum open so users can still match against arbitrary strings as we add new codes without upgrading SDK
- Expose `WebSocketError` export at top level for consumers to reference when handling errors