### PR TITLE
websockets improvements

### DIFF
--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -1,0 +1,488 @@
+/**
+ * Examples for Cartesia JS SDK v3.x
+ *
+ * Run an example:
+ *   CARTESIA_API_KEY=... npx ts-node examples/examples.ts <functionName>
+ */
+
+import * as fs from 'fs';
+import Cartesia, {
+  APIError,
+  NotFoundError,
+  RateLimitError,
+  BadRequestError,
+  AuthenticationError,
+} from '@cartesia/cartesia-js';
+import type { WebsocketResponse } from '@cartesia/cartesia-js/resources/tts/tts';
+
+// The generated WebsocketResponse types don't include all wire fields (e.g. `data`
+// on chunks, `word_timestamps` on timestamps). We use a small helper to access them.
+function chunkData(event: WebsocketResponse): Buffer | null {
+  const data = (event as any).data as string | undefined;
+  return data ? Buffer.from(data, 'base64') : null;
+}
+
+// =============================================================================
+// Client Initialization
+// =============================================================================
+
+function createClient(): Cartesia {
+  return new Cartesia({ apiKey: process.env['CARTESIA_API_KEY'] });
+}
+
+// =============================================================================
+// TTS Generate (Bytes)
+// =============================================================================
+
+async function ttsGenerateToFile(client: Cartesia): Promise<void> {
+  /** Use generate() to get a wav Response and write it to a file. */
+  const response = await client.tts.generate({
+    model_id: 'sonic-3',
+    transcript: 'Hello, world!',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'wav', encoding: 'pcm_f32le', sample_rate: 44100 },
+  });
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  fs.writeFileSync('output.wav', buffer);
+  console.log('Saved audio to output.wav');
+  console.log('Play with: ffplay -f wav output.wav');
+}
+
+// =============================================================================
+// TTS WebSocket
+// =============================================================================
+
+async function ttsWebsocketBasic(client: Cartesia): Promise<void> {
+  /** Basic WebSocket usage with generate(). */
+  const ws = await client.tts.websocket();
+  ws.on('error', (err) => console.error('WS error:', err.message));
+
+  const filename = `tts_websocket_basic_${timestamp()}.pcm`;
+  const file = fs.createWriteStream(filename);
+
+  for await (const event of ws.generate({
+    model_id: 'sonic-3',
+    transcript: 'Hello, world!',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+  })) {
+    if (event.type === 'chunk') {
+      const audio = chunkData(event);
+      if (audio) file.write(audio);
+    }
+  }
+
+  file.end();
+  ws.close();
+  console.log(`Saved audio to ${filename}`);
+  console.log(`Play with:\n  $ ffplay -f f32le -ar 44100 ${filename}`);
+}
+
+async function ttsWebsocketContinuations(client: Cartesia): Promise<void> {
+  /** Streaming a transcript split into multiple parts, using continuations. */
+  const ws = await client.tts.websocket();
+  ws.on('error', (err) => console.error('WS error:', err.message));
+
+  const ctx = ws.context({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+  });
+
+  for (const part of ['The road ', 'goes ever ', 'on and ', 'on.']) {
+    await ctx.push({ transcript: part });
+  }
+  await ctx.done();
+
+  const filename = `tts_websocket_continuations_${timestamp()}.pcm`;
+  const file = fs.createWriteStream(filename);
+
+  for await (const event of ctx.receive()) {
+    if (event.type === 'chunk') {
+      const audio = chunkData(event);
+      if (audio) file.write(audio);
+    }
+  }
+
+  file.end();
+  ws.close();
+  console.log(`Saved audio to ${filename}`);
+  console.log(`Play with:\n  $ ffplay -f f32le -ar 44100 ${filename}`);
+}
+
+async function ttsWebsocketFlushing(client: Cartesia): Promise<void> {
+  /** Demonstrates manual flushing to separate audio from different transcripts. */
+  const ws = await client.tts.websocket();
+  ws.on('error', (err) => console.error('WS error:', err.message));
+
+  const ctx = ws.context({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+  });
+
+  // 1. Send first transcript
+  console.log('Sending first transcript...');
+  await ctx.push({ transcript: 'Stay hungry, ' });
+
+  // 2. Flush — forces all buffered audio for the first transcript to be generated.
+  console.log('Flushing...');
+  await ctx.flush();
+
+  // 3. Send second transcript
+  console.log('Sending second transcript...');
+  await ctx.push({ transcript: 'stay foolish.' });
+
+  await ctx.done();
+
+  const ts = timestamp();
+  const files: Map<number, fs.WriteStream> = new Map();
+
+  for await (const event of ctx.receive()) {
+    if (event.type === 'chunk') {
+      const audio = chunkData(event);
+      if (audio) {
+        const flushId = (event as any).flush_id ?? 0;
+        if (!files.has(flushId)) {
+          const name = `tts_flush_${flushId}_${ts}.pcm`;
+          files.set(flushId, fs.createWriteStream(name));
+          console.log(`Created new file for flush_id ${flushId}: ${name}`);
+        }
+        files.get(flushId)!.write(audio);
+      }
+    } else if (event.type === 'flush_done') {
+      console.log(`Flush done received for flush_id: ${(event as any).flush_id}`);
+    }
+  }
+
+  for (const f of files.values()) f.end();
+  ws.close();
+
+  console.log('\nFinished. Play the generated audio files with:');
+  for (const [flushId, f] of files) {
+    console.log(`  Flush ID ${flushId}: ffplay -f f32le -ar 44100 ${(f as any).path}`);
+  }
+}
+
+async function ttsWebsocketEmotion(client: Cartesia): Promise<void> {
+  /** Demonstrates changing emotion mid-stream using generation_config. */
+  const ws = await client.tts.websocket();
+  ws.on('error', (err) => console.error('WS error:', err.message));
+
+  const ctx = ws.context({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+  });
+
+  console.log('Sending neutral text...');
+  await ctx.push({ transcript: 'Well maybe if you just ' });
+
+  console.log('Sending angry text...');
+  await ctx.send({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+    transcript: 'loosen up a little!',
+    continue: true,
+    generation_config: { emotion: 'angry' },
+  });
+
+  await ctx.done();
+
+  const filename = `tts_emotion_${timestamp()}.pcm`;
+  const file = fs.createWriteStream(filename);
+
+  for await (const event of ctx.receive()) {
+    if (event.type === 'chunk') {
+      const audio = chunkData(event);
+      if (audio) file.write(audio);
+    }
+  }
+
+  file.end();
+  ws.close();
+  console.log(`Saved audio to ${filename}`);
+  console.log(`Play with: ffplay -f f32le -ar 44100 ${filename}`);
+}
+
+async function ttsWebsocketSpeed(client: Cartesia): Promise<void> {
+  /** Demonstrates changing speed mid-stream using generation_config. */
+  const ws = await client.tts.websocket();
+  ws.on('error', (err) => console.error('WS error:', err.message));
+
+  const ctx = ws.context({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+  });
+
+  console.log('Sending normal speed text...');
+  await ctx.push({ transcript: 'I am speaking at a normal pace. ' });
+
+  console.log('Sending fast speed text...');
+  await ctx.send({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+    transcript: 'But now I am speaking much faster!',
+    continue: true,
+    generation_config: { speed: 1.5 },
+  });
+
+  await ctx.done();
+
+  const filename = `tts_speed_${timestamp()}.pcm`;
+  const file = fs.createWriteStream(filename);
+
+  for await (const event of ctx.receive()) {
+    if (event.type === 'chunk') {
+      const audio = chunkData(event);
+      if (audio) file.write(audio);
+    }
+  }
+
+  file.end();
+  ws.close();
+  console.log(`Saved audio to ${filename}`);
+  console.log(`Play with: ffplay -f f32le -ar 44100 ${filename}`);
+}
+
+async function ttsWebsocketConcurrentContexts(client: Cartesia): Promise<void> {
+  /** Two contexts on one connection, received concurrently via Promise.all(). */
+  const ws = await client.tts.websocket();
+  ws.on('error', (err) => console.error('WS error:', err.message));
+
+  const ctx1 = ws.context({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+  });
+
+  const ctx2 = ws.context({
+    model_id: 'sonic-3',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+  });
+
+  // Send to both contexts before receiving.
+  await ctx1.push({
+    transcript:
+      'Context one is speaking now. This is a longer transcript to ensure that ' +
+      'audio chunks from both contexts are interleaved on the wire. ' +
+      'The quick brown fox jumps over the lazy dog.',
+  });
+  await ctx1.done();
+
+  await ctx2.push({
+    transcript:
+      'Context two has a different message. We want to verify that the routing ' +
+      'logic correctly separates the audio streams. ' +
+      'Pack my box with five dozen liquor jugs.',
+  });
+  await ctx2.done();
+
+  const ts = timestamp();
+
+  async function collect(ctx: { receive: typeof ctx1.receive }, filename: string): Promise<void> {
+    const file = fs.createWriteStream(filename);
+    for await (const event of ctx.receive()) {
+      if (event.type === 'chunk') {
+        const audio = chunkData(event);
+        if (audio) file.write(audio);
+      }
+    }
+    file.end();
+  }
+
+  const filename1 = `tts_concurrent_ctx1_${ts}.pcm`;
+  const filename2 = `tts_concurrent_ctx2_${ts}.pcm`;
+
+  await Promise.all([collect(ctx1, filename1), collect(ctx2, filename2)]);
+
+  ws.close();
+  console.log(`Saved context 1 audio to ${filename1}`);
+  console.log(`Saved context 2 audio to ${filename2}`);
+  console.log('Play with:');
+  console.log(`  ffplay -f f32le -ar 44100 ${filename1}`);
+  console.log(`  ffplay -f f32le -ar 44100 ${filename2}`);
+}
+
+async function ttsWebsocketResponseHandling(client: Cartesia): Promise<void> {
+  /** WebSocket response type handling with timestamps. */
+  const ws = await client.tts.websocket();
+  ws.on('error', (err) => console.error('WS error:', err.message));
+
+  const filename = `tts_websocket_response_handling_${timestamp()}.pcm`;
+  const file = fs.createWriteStream(filename);
+
+  for await (const event of ws.generate({
+    model_id: 'sonic-3',
+    transcript: 'Hello, world!',
+    voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+    output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
+    add_timestamps: true,
+  })) {
+    if (event.type === 'chunk') {
+      const audio = chunkData(event);
+      if (audio) file.write(audio);
+    } else if (event.type === 'timestamps') {
+      const wt = (event as any).word_timestamps;
+      if (wt) {
+        console.log(`Words: ${wt.words}, Starts: ${wt.start}, Ends: ${wt.end}`);
+      }
+    } else if (event.type === 'error') {
+      throw new Error(JSON.stringify(event));
+    }
+  }
+
+  file.end();
+  ws.close();
+  console.log(`Saved audio to ${filename}`);
+  console.log(`Play with: ffplay -f f32le -ar 44100 ${filename}`);
+}
+
+// =============================================================================
+// Voices API
+// =============================================================================
+
+async function voicesList(client: Cartesia): Promise<void> {
+  /** List voices with pagination. */
+  for await (const voice of client.voices.list({ limit: 10 })) {
+    console.log(voice.name);
+  }
+}
+
+async function voicesGet(client: Cartesia): Promise<void> {
+  /** Get a specific voice. */
+  const voice = await client.voices.get('6ccbfb76-1fc6-48f7-b71d-91ac6298247b');
+  console.log(voice.name);
+}
+
+async function voicesClone(client: Cartesia): Promise<void> {
+  /** Clone a voice from an audio clip. */
+  const clip = fs.createReadStream('sample.wav');
+  const voice = await client.voices.clone({
+    clip,
+    name: 'My Voice',
+    description: 'A custom voice',
+    language: 'en',
+  });
+  console.log('Cloned voice:', voice.id);
+}
+
+async function voicesUpdate(client: Cartesia): Promise<void> {
+  /** Update a voice. */
+  await client.voices.update('voice-id', {
+    name: 'Updated Name',
+    description: 'Updated description',
+  });
+}
+
+async function voicesDelete(client: Cartesia): Promise<void> {
+  /** Delete a voice. */
+  await client.voices.delete('voice-id');
+}
+
+// =============================================================================
+// STT (Speech-to-Text)
+// =============================================================================
+
+async function sttTranscribe(client: Cartesia): Promise<void> {
+  /** Transcribe audio with word timestamps. */
+  const file = fs.createReadStream('audio.wav');
+  const response = await client.stt.transcribe({
+    file,
+    model: 'ink-whisper',
+    language: 'en',
+    timestamp_granularities: ['word'],
+  });
+  console.log(response.text);
+  if (response.words) {
+    for (const word of response.words) {
+      console.log(`${word.word}: ${word.start}s - ${word.end}s`);
+    }
+  }
+}
+
+// =============================================================================
+// Error Handling
+// =============================================================================
+
+async function errorHandling(client: Cartesia): Promise<void> {
+  /** Example of error handling with SDK exceptions. */
+  try {
+    await client.tts.generate({
+      model_id: 'sonic-3',
+      transcript: 'Hello, world!',
+      voice: { mode: 'id', id: '6ccbfb76-1fc6-48f7-b71d-91ac6298247b' },
+      output_format: { container: 'wav', encoding: 'pcm_f32le', sample_rate: 44100 },
+    });
+  } catch (e) {
+    if (e instanceof BadRequestError) {
+      console.log(`Bad request: ${e.message}`);
+    } else if (e instanceof AuthenticationError) {
+      console.log(`Auth failed: ${e.message}`);
+    } else if (e instanceof NotFoundError) {
+      console.log(`Not found: ${e.message}`);
+    } else if (e instanceof RateLimitError) {
+      console.log(`Rate limited: ${e.message}`);
+    } else if (e instanceof APIError) {
+      console.log(`API error: ${e.message}`);
+    } else {
+      throw e;
+    }
+  }
+}
+
+// =============================================================================
+// Runner
+// =============================================================================
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+}
+
+const examples: Record<string, (client: Cartesia) => Promise<void>> = {
+  ttsGenerateToFile,
+  ttsWebsocketBasic,
+  ttsWebsocketContinuations,
+  ttsWebsocketFlushing,
+  ttsWebsocketEmotion,
+  ttsWebsocketSpeed,
+  ttsWebsocketConcurrentContexts,
+  ttsWebsocketResponseHandling,
+  voicesList,
+  voicesGet,
+  voicesClone,
+  voicesUpdate,
+  voicesDelete,
+  sttTranscribe,
+  errorHandling,
+};
+
+async function main() {
+  const name = process.argv[2];
+
+  if (!name || !(name in examples)) {
+    console.log('Usage: npx ts-node examples/examples.ts <functionName>');
+    console.log(`Available: ${Object.keys(examples).join(', ')}`);
+    process.exit(1);
+  }
+
+  if (!process.env['CARTESIA_API_KEY']) {
+    console.error('Error: CARTESIA_API_KEY environment variable not set.');
+    process.exit(1);
+  }
+
+  const client = createClient();
+  try {
+    await examples[name]!(client);
+  } catch (e) {
+    console.error(`Error: ${e}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/resources/tts/index.ts
+++ b/src/resources/tts/index.ts
@@ -17,3 +17,4 @@ export {
 } from './tts';
 
 export { TTSWS, TTSWSContext, type ContextOptions, type ContextGenerateRequest } from './ws';
+export { WebSocketTimeoutError } from './internal-base';

--- a/src/resources/tts/internal-base.ts
+++ b/src/resources/tts/internal-base.ts
@@ -19,6 +19,17 @@ export class WebSocketError extends CartesiaError {
   }
 }
 
+export class WebSocketTimeoutError extends CartesiaError {
+  readonly contextId: string;
+  readonly timeoutMs: number;
+
+  constructor(contextId: string, timeoutMs: number) {
+    super(`Timed out waiting for response on context ${contextId} after ${timeoutMs}ms`);
+    this.contextId = contextId;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
 
 type WebsocketEvents = Simplify<
@@ -36,7 +47,7 @@ export abstract class TTSEmitter extends EventEmitter<WebsocketEvents> {
   /**
    * Send an event to the API.
    */
-  abstract send(event: TTSAPI.WebsocketClientEvent): void;
+  abstract send(event: TTSAPI.WebsocketClientEvent): void | Promise<void>;
 
   /**
    * Close the websocket connection.

--- a/src/resources/tts/ws.ts
+++ b/src/resources/tts/ws.ts
@@ -2,7 +2,7 @@
 
 import * as WS from 'ws';
 import { humanId } from 'human-id';
-import { TTSEmitter, buildURL } from './internal-base';
+import { TTSEmitter, WebSocketTimeoutError, buildURL } from './internal-base';
 import * as TTSAPI from './tts';
 import type { Cartesia } from '../../client';
 
@@ -19,6 +19,13 @@ export interface ContextOptions {
   voice: TTSAPI.VoiceSpecifier;
   output_format: TTSAPI.GenerationRequest['output_format'];
   contextId?: string;
+  /** Receive timeout in milliseconds. If set, receive() will throw WebSocketTimeoutError after this duration of inactivity. */
+  timeout?: number;
+}
+
+interface ContextQueueEntry {
+  queue: TTSAPI.WebsocketResponse[];
+  resolve: (() => void) | null;
 }
 
 /**
@@ -26,7 +33,8 @@ export interface ContextOptions {
  */
 export class TTSWSContext {
   private _ws: TTSWS;
-  private _options: Omit<ContextOptions, 'contextId'>;
+  private _options: Omit<ContextOptions, 'contextId' | 'timeout'>;
+  private _timeout: number | undefined;
   readonly contextId: string;
 
   constructor(ws: TTSWS, options: ContextOptions) {
@@ -36,15 +44,17 @@ export class TTSWSContext {
       voice: options.voice,
       output_format: options.output_format,
     };
+    this._timeout = options.timeout;
     this.contextId = options.contextId ?? humanId({ separator: '-', capitalize: false });
   }
 
   /**
    * Send a transcript chunk with continue: true.
    * Call this multiple times to stream transcript chunks, then call done() to finish.
+   * If flush is true, sends an additional flush request after the transcript.
    */
-  async push(options: { transcript: string }) {
-    this._ws.send({
+  async push(options: { transcript: string; flush?: boolean }) {
+    await this._ws.send({
       model_id: this._options.model_id,
       voice: this._options.voice,
       output_format: this._options.output_format,
@@ -52,6 +62,10 @@ export class TTSWSContext {
       context_id: this.contextId,
       continue: true,
     });
+
+    if (options.flush) {
+      await this.flush();
+    }
   }
 
   /**
@@ -59,7 +73,7 @@ export class TTSWSContext {
    * Sends an empty transcript with continue: false.
    */
   async done() {
-    this._ws.send({
+    await this._ws.send({
       model_id: this._options.model_id,
       voice: this._options.voice,
       output_format: this._options.output_format,
@@ -74,59 +88,84 @@ export class TTSWSContext {
    * Use this for streaming multiple transcript chunks.
    * The context_id is automatically set.
    */
-  send(request: ContextGenerateRequest) {
-    this._ws.send({
+  async send(request: ContextGenerateRequest) {
+    await this._ws.send({
       ...request,
       context_id: this.contextId,
     });
   }
 
   /**
+   * Flush any buffered audio for this context.
+   * Sends an empty transcript with flush=true and continue=true.
+   * This is always sent as a separate request per the API requirement.
+   */
+  async flush() {
+    await this._ws.send({
+      model_id: this._options.model_id,
+      voice: this._options.voice,
+      output_format: this._options.output_format,
+      transcript: '',
+      context_id: this.contextId,
+      continue: true,
+      flush: true,
+    });
+  }
+
+  /**
    * Iterate over responses for this context.
    * Completes when a "done" event is received.
+   * Events for other contexts are properly routed to their queues, not dropped.
+   *
+   * @param options.timeout - Override the context-level timeout (ms) for this receive call.
    */
-  async *receive(): AsyncGenerator<TTSAPI.WebsocketResponse> {
-    const queue: TTSAPI.WebsocketResponse[] = [];
-    let done = false;
-    let error: Error | null = null;
-    let resolve: (() => void) | null = null;
-
-    const onEvent = (event: TTSAPI.WebsocketResponse) => {
-      // Filter by context_id
-      if ('context_id' in event && event.context_id !== this.contextId) {
-        return;
-      }
-      queue.push(event);
-      if (event.type === 'done' || event.type === 'error') {
-        done = true;
-        if (event.type === 'error') {
-          error = new Error(JSON.stringify(event));
-        }
-      }
-      resolve?.();
-    };
-
-    this._ws.on('event', onEvent);
+  async *receive(options?: { timeout?: number }): AsyncGenerator<TTSAPI.WebsocketResponse> {
+    const timeout = options?.timeout ?? this._timeout;
 
     try {
-      while (!done || queue.length > 0) {
-        if (queue.length > 0) {
-          const event = queue.shift()!;
+      while (true) {
+        const entry = this._ws._getContextQueue(this.contextId);
+        if (!entry) {
+          // Queue was removed (context unregistered by reconnect or cancel), stop.
+          return;
+        }
+
+        if (entry.queue.length > 0) {
+          const event = entry.queue.shift()!;
           yield event;
           if (event.type === 'done') {
             return;
           }
           if (event.type === 'error') {
-            throw error;
+            throw new Error(JSON.stringify(event));
           }
         } else {
-          await new Promise<void>((r) => {
-            resolve = r;
+          // Wait for the next event to be pushed into the queue.
+          const waitPromise = new Promise<void>((r) => {
+            entry.resolve = r;
           });
+
+          if (timeout !== undefined) {
+            let timer: ReturnType<typeof setTimeout>;
+            const timeoutPromise = new Promise<'timeout'>((r) => {
+              timer = setTimeout(() => r('timeout'), timeout);
+            });
+
+            const result = await Promise.race([waitPromise.then(() => 'event' as const), timeoutPromise]);
+
+            clearTimeout(timer!);
+
+            if (result === 'timeout') {
+              entry.resolve = null;
+              throw new WebSocketTimeoutError(this.contextId, timeout);
+            }
+          } else {
+            await waitPromise;
+          }
         }
       }
     } finally {
-      this._ws.off('event', onEvent);
+      this._ws._unregisterContext(this.contextId);
     }
   }
 
@@ -144,21 +183,30 @@ export class TTSWSContext {
   /**
    * Cancel this context to stop generating speech.
    */
-  cancel() {
-    this._ws.cancelContext(this.contextId);
+  async cancel() {
+    await this._ws.cancelContext(this.contextId);
+    this._ws._unregisterContext(this.contextId);
   }
 }
 
 export class TTSWS extends TTSEmitter {
   url: URL;
-  socket: WS.WebSocket;
+  socket!: WS.WebSocket;
   private client: Cartesia;
   private _ready: Promise<void>;
+  private _wsOptions: WS.ClientOptions | undefined;
+  private _contextQueues: Map<string, ContextQueueEntry> = new Map();
 
   constructor(client: Cartesia, options?: WS.ClientOptions | undefined) {
     super();
     this.client = client;
+    this._wsOptions = options;
     this.url = buildURL(client);
+    this._ready = Promise.resolve();
+    this._initSocket(options);
+  }
+
+  private _initSocket(options?: WS.ClientOptions | undefined): void {
     this.socket = new WS.WebSocket(this.url, {
       ...options,
       headers: {
@@ -184,6 +232,7 @@ export class TTSWS extends TTSEmitter {
       })();
 
       if (event) {
+        // Always emit on EventEmitter for backwards compatibility and global listeners.
         this._emit('event', event);
 
         if (event.type === 'error') {
@@ -191,6 +240,17 @@ export class TTSWS extends TTSEmitter {
         } else {
           // @ts-ignore TS isn't smart enough to get the relationship right here
           this._emit(event.type, event);
+        }
+
+        // Route to per-context queue if registered.
+        const ctxId = 'context_id' in event ? (event as any).context_id : null;
+        if (ctxId && this._contextQueues.has(ctxId)) {
+          const entry = this._contextQueues.get(ctxId)!;
+          entry.queue.push(event);
+          if (entry.resolve) {
+            entry.resolve();
+            entry.resolve = null;
+          }
         }
       }
     });
@@ -200,7 +260,8 @@ export class TTSWS extends TTSEmitter {
     });
   }
 
-  send(event: TTSAPI.WebsocketClientEvent) {
+  async send(event: TTSAPI.WebsocketClientEvent) {
+    await this._ensureConnected();
     try {
       this.socket.send(JSON.stringify(event));
     } catch (err) {
@@ -236,7 +297,7 @@ export class TTSWS extends TTSEmitter {
     this.on('event', onEvent);
 
     try {
-      this.send(request);
+      await this.send(request);
 
       while (!done || queue.length > 0) {
         if (queue.length > 0) {
@@ -262,15 +323,18 @@ export class TTSWS extends TTSEmitter {
   /**
    * Cancel a context to stop generating speech for it.
    */
-  cancelContext(contextId: string) {
-    this.send({ cancel: true, context_id: contextId });
+  async cancelContext(contextId: string) {
+    await this.send({ cancel: true, context_id: contextId });
   }
 
   /**
    * Create a new context with the given options.
+   * Registers a per-context event queue for proper multi-context routing.
    */
   context(options: ContextOptions): TTSWSContext {
-    return new TTSWSContext(this, options);
+    const ctx = new TTSWSContext(this, options);
+    this._registerContext(ctx.contextId);
+    return ctx;
   }
 
   close(props?: { code: number; reason: string }) {
@@ -287,6 +351,46 @@ export class TTSWS extends TTSEmitter {
   async connect(): Promise<this> {
     await this._ready;
     return this;
+  }
+
+  /** Register a per-context queue. Called by context(). */
+  _registerContext(contextId: string): void {
+    if (this._contextQueues.has(contextId)) {
+      throw new Error(`Context ${contextId} is already registered`);
+    }
+    this._contextQueues.set(contextId, { queue: [], resolve: null });
+  }
+
+  /** Unregister a per-context queue. Called on context completion or cancellation. */
+  _unregisterContext(contextId: string): void {
+    this._contextQueues.delete(contextId);
+  }
+
+  /** Get the queue entry for a context, or undefined. */
+  _getContextQueue(contextId: string): ContextQueueEntry | undefined {
+    return this._contextQueues.get(contextId);
+  }
+
+  /**
+   * Check if the connection is open; if closed, reconnect transparently.
+   * Clears all context queues on reconnect since server-side state is lost.
+   */
+  private async _ensureConnected(): Promise<void> {
+    const state = this.socket.readyState;
+    if (state === WS.WebSocket.CLOSING || state === WS.WebSocket.CLOSED) {
+      // Wake up any waiting receive() calls so they can exit cleanly.
+      for (const [, entry] of this._contextQueues) {
+        if (entry.resolve) {
+          entry.resolve();
+          entry.resolve = null;
+        }
+      }
+      this._contextQueues.clear();
+
+      // Create a fresh socket connection.
+      this._initSocket(this._wsOptions);
+      await this._ready;
+    }
   }
 
   private authHeaders(): Record<string, string> {

--- a/tests/ws-routing.test.ts
+++ b/tests/ws-routing.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for WebSocket multi-context routing.
+ *
+ * Ported from cartesia-python/tests/test_dispatcher.py. These unit tests
+ * verify two key properties using a mock WebSocket (no API key required):
+ *
+ * 1. Events are buffered in per-context queues before receive() is called.
+ * 2. A slow reader on one context does not block readers on other contexts.
+ *
+ * Additional tests cover correct routing by context_id and receive timeouts.
+ */
+
+import { TTSWS } from '@cartesia/cartesia-js/resources/tts/ws';
+import { WebSocketTimeoutError } from '@cartesia/cartesia-js/resources/tts/internal-base';
+import type { WebsocketResponse } from '@cartesia/cartesia-js/resources/tts/tts';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const CONTEXT_OPTIONS = {
+  model_id: 'sonic-3',
+  voice: { id: 'test-voice', mode: 'id' as const },
+  output_format: { container: 'raw' as const, encoding: 'pcm_f32le' as const, sample_rate: 44100 as const },
+};
+
+/** Create a TTSWS whose underlying socket will fail to connect (that's fine —
+ *  we inject messages by emitting directly on the socket). */
+function createTestWS(): TTSWS {
+  const fakeClient = { baseURL: 'http://127.0.0.1:1', token: 'test' } as any;
+  const ws = new TTSWS(fakeClient);
+  // Suppress connection‑error noise.
+  ws.on('error', () => {});
+  ws.connect().catch(() => {});
+  return ws;
+}
+
+/** Simulate a server‑sent message by emitting directly on the socket. */
+function injectEvent(ws: TTSWS, event: Record<string, unknown>) {
+  ws.socket.emit('message', Buffer.from(JSON.stringify(event)), false);
+}
+
+function makeChunk(contextId: string, seq: number): Record<string, unknown> {
+  return {
+    type: 'chunk',
+    context_id: contextId,
+    data: `audio_${seq}`,
+    done: false,
+    status_code: 200,
+  };
+}
+
+function makeDone(contextId: string): Record<string, unknown> {
+  return {
+    type: 'done',
+    context_id: contextId,
+    done: true,
+    status_code: 200,
+  };
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WebSocket multi-context routing', () => {
+  test('events are buffered in context queue before receive() is called', async () => {
+    const ws = createTestWS();
+    const NUM_CHUNKS = 50;
+    const CTX_ID = 'buffer-test';
+
+    const ctx = ws.context({ ...CONTEXT_OPTIONS, contextId: CTX_ID });
+
+    // Push many messages before anyone calls receive().
+    for (let i = 0; i < NUM_CHUNKS; i++) {
+      injectEvent(ws, makeChunk(CTX_ID, i));
+    }
+    injectEvent(ws, makeDone(CTX_ID));
+
+    // All messages should already be sitting in the context queue.
+    const entry = ws._getContextQueue(CTX_ID);
+    expect(entry).toBeDefined();
+    expect(entry!.queue.length).toBe(NUM_CHUNKS + 1); // chunks + done
+
+    // Now consume via receive() — everything should already be available.
+    const chunks: WebsocketResponse[] = [];
+    for await (const event of ctx.receive()) {
+      if (event.type === 'chunk') {
+        chunks.push(event);
+      }
+    }
+    expect(chunks.length).toBe(NUM_CHUNKS);
+
+    ws.close();
+  });
+
+  test('events are routed to the correct context', async () => {
+    const ws = createTestWS();
+
+    const ctx1 = ws.context({ ...CONTEXT_OPTIONS, contextId: 'ctx-1' });
+    const ctx2 = ws.context({ ...CONTEXT_OPTIONS, contextId: 'ctx-2' });
+
+    // Inject interleaved messages for both contexts.
+    injectEvent(ws, makeChunk('ctx-1', 0));
+    injectEvent(ws, makeChunk('ctx-2', 0));
+    injectEvent(ws, makeChunk('ctx-1', 1));
+    injectEvent(ws, makeChunk('ctx-2', 1));
+    injectEvent(ws, makeDone('ctx-1'));
+    injectEvent(ws, makeDone('ctx-2'));
+
+    // Each context should only see its own events.
+    const ctx1Events: WebsocketResponse[] = [];
+    for await (const event of ctx1.receive()) {
+      ctx1Events.push(event);
+    }
+
+    const ctx2Events: WebsocketResponse[] = [];
+    for await (const event of ctx2.receive()) {
+      ctx2Events.push(event);
+    }
+
+    expect(ctx1Events.filter((e) => e.type === 'chunk').length).toBe(2);
+    expect(ctx1Events[ctx1Events.length - 1]!.type).toBe('done');
+
+    expect(ctx2Events.filter((e) => e.type === 'chunk').length).toBe(2);
+    expect(ctx2Events[ctx2Events.length - 1]!.type).toBe('done');
+
+    // Verify context_ids are correct.
+    for (const event of ctx1Events) {
+      expect((event as any).context_id).toBe('ctx-1');
+    }
+    for (const event of ctx2Events) {
+      expect((event as any).context_id).toBe('ctx-2');
+    }
+
+    ws.close();
+  });
+
+  test('slow reader does not block fast reader', async () => {
+    const ws = createTestWS();
+    const NUM_CHUNKS = 20;
+    const SLOW_DELAY = 50; // ms per event for slow reader
+
+    const ctxSlow = ws.context({ ...CONTEXT_OPTIONS, contextId: 'slow-ctx' });
+    const ctxFast = ws.context({ ...CONTEXT_OPTIONS, contextId: 'fast-ctx' });
+
+    // Inject interleaved messages for both contexts.
+    for (let i = 0; i < NUM_CHUNKS; i++) {
+      injectEvent(ws, makeChunk('slow-ctx', i));
+      injectEvent(ws, makeChunk('fast-ctx', i));
+    }
+    injectEvent(ws, makeDone('slow-ctx'));
+    injectEvent(ws, makeDone('fast-ctx'));
+
+    // Slow reader: sleeps between every event.
+    async function slowCollect(): Promise<WebsocketResponse[]> {
+      const chunks: WebsocketResponse[] = [];
+      for await (const event of ctxSlow.receive()) {
+        if (event.type === 'chunk') chunks.push(event);
+        await sleep(SLOW_DELAY);
+      }
+      return chunks;
+    }
+
+    // Fast reader: no delays.
+    let fastStart = 0;
+    let fastEnd = 0;
+    async function fastCollect(): Promise<WebsocketResponse[]> {
+      fastStart = performance.now();
+      const chunks: WebsocketResponse[] = [];
+      for await (const event of ctxFast.receive()) {
+        if (event.type === 'chunk') chunks.push(event);
+      }
+      fastEnd = performance.now();
+      return chunks;
+    }
+
+    const [slowChunks, fastChunks] = await Promise.all([slowCollect(), fastCollect()]);
+
+    expect(slowChunks.length).toBe(NUM_CHUNKS);
+    expect(fastChunks.length).toBe(NUM_CHUNKS);
+
+    // The fast reader should finish nearly instantly (all events already queued).
+    // The slow reader needs at least NUM_CHUNKS * SLOW_DELAY ≈ 1000ms.
+    const fastDuration = fastEnd - fastStart;
+    const slowMinDuration = NUM_CHUNKS * SLOW_DELAY;
+
+    expect(fastDuration).toBeLessThan(slowMinDuration / 2);
+
+    ws.close();
+  });
+
+  test('context queue is cleaned up after receive() completes', async () => {
+    const ws = createTestWS();
+
+    const ctx = ws.context({ ...CONTEXT_OPTIONS, contextId: 'cleanup-test' });
+
+    expect(ws._getContextQueue('cleanup-test')).toBeDefined();
+
+    injectEvent(ws, makeChunk('cleanup-test', 0));
+    injectEvent(ws, makeDone('cleanup-test'));
+
+    // Drain receive.
+    for await (const _event of ctx.receive()) {
+      // consume
+    }
+
+    // Queue should be cleaned up after done.
+    expect(ws._getContextQueue('cleanup-test')).toBeUndefined();
+
+    ws.close();
+  });
+
+  test('cancel() unregisters the context queue', async () => {
+    const ws = createTestWS();
+
+    const ctx = ws.context({ ...CONTEXT_OPTIONS, contextId: 'cancel-test' });
+    expect(ws._getContextQueue('cancel-test')).toBeDefined();
+
+    await ctx.cancel();
+    expect(ws._getContextQueue('cancel-test')).toBeUndefined();
+
+    ws.close();
+  });
+
+  test('receive() with timeout throws WebSocketTimeoutError', async () => {
+    const ws = createTestWS();
+
+    const ctx = ws.context({
+      ...CONTEXT_OPTIONS,
+      contextId: 'timeout-test',
+      timeout: 100,
+    });
+
+    // Inject one chunk but no done event — receive will wait and timeout.
+    injectEvent(ws, makeChunk('timeout-test', 0));
+
+    const events: WebsocketResponse[] = [];
+    let thrownError: unknown;
+    try {
+      for await (const event of ctx.receive()) {
+        events.push(event);
+      }
+    } catch (err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).toBeInstanceOf(WebSocketTimeoutError);
+    // Should have received the one chunk before timing out.
+    expect(events.length).toBe(1);
+    expect(events[0]!.type).toBe('chunk');
+
+    ws.close();
+  });
+
+  test('receive() per-call timeout overrides context timeout', async () => {
+    const ws = createTestWS();
+
+    const ctx = ws.context({
+      ...CONTEXT_OPTIONS,
+      contextId: 'timeout-override',
+      timeout: 10_000, // very long default
+    });
+
+    injectEvent(ws, makeChunk('timeout-override', 0));
+
+    const start = performance.now();
+    let thrownError: unknown;
+    try {
+      for await (const _event of ctx.receive({ timeout: 100 })) {
+        // consume
+      }
+    } catch (err) {
+      thrownError = err;
+    }
+    const elapsed = performance.now() - start;
+
+    expect(thrownError).toBeInstanceOf(WebSocketTimeoutError);
+    // Should have timed out after ~100ms, not 10s.
+    expect(elapsed).toBeLessThan(1000);
+
+    ws.close();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core TTS WebSocket behavior (context routing, async send/reconnect, lifecycle cleanup), which could affect streaming reliability and backward compatibility for consumers relying on prior event ordering/handling.
> 
> **Overview**
> Improves the TTS WebSocket API to better support *multiple concurrent contexts* by introducing per-context event queues so interleaved events are buffered and routed correctly (no longer dropped/blocked by other contexts).
> 
> Adds context-level and per-call `receive()` timeouts via a new `WebSocketTimeoutError`, plus explicit context lifecycle handling (auto-unregister on completion/cancel) and transparent reconnect-on-send when the socket is closed.
> 
> Extends the context helper with `flush()` (and `push({ flush: true })`) and makes WebSocket `send()`/context operations async; adds a new `examples/examples.ts` script demonstrating websocket patterns (continuations, flushing, concurrent contexts, timestamps) and unit tests covering routing, buffering, cleanup, and timeout behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2048085aa72ae56093921e5deb3cd453feae0d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->