### PR TITLE
context fixes

### DIFF
--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -140,6 +140,11 @@ async function ttsWebsocketFlushing(client: Cartesia): Promise<void> {
   const files: Map<number, fs.WriteStream> = new Map();
 
   for await (const event of ctx.receive()) {
+    // Log every response, but redact audio data to avoid swamping the console.
+    const loggable = { ...(event as any) };
+    if (loggable.data) loggable.data = '[...]';
+    console.log('Event:', JSON.stringify(loggable));
+
     if (event.type === 'chunk') {
       const audio = chunkData(event);
       if (audio) {
@@ -147,12 +152,9 @@ async function ttsWebsocketFlushing(client: Cartesia): Promise<void> {
         if (!files.has(flushId)) {
           const name = `tts_flush_${flushId}_${ts}.pcm`;
           files.set(flushId, fs.createWriteStream(name));
-          console.log(`Created new file for flush_id ${flushId}: ${name}`);
         }
         files.get(flushId)!.write(audio);
       }
-    } else if (event.type === 'flush_done') {
-      console.log(`Flush done received for flush_id: ${(event as any).flush_id}`);
     }
   }
 

--- a/src/resources/tts/ws.ts
+++ b/src/resources/tts/ws.ts
@@ -172,8 +172,15 @@ export class TTSWSContext {
   /**
    * Send a generation request and iterate over the responses.
    * The context_id is automatically set.
+   *
+   * Note: this uses TTSWS.generate()'s own EventEmitter-based collection,
+   * so the per-context queue is unregistered to avoid accumulating events
+   * in both places.
    */
   async *generate(request: ContextGenerateRequest): AsyncGenerator<TTSAPI.WebsocketResponse> {
+    // Unregister our queue — ws.generate() uses its own EventEmitter listener
+    // and would cause events to accumulate in both places (memory leak).
+    this._ws._unregisterContext(this.contextId);
     yield* this._ws.generate({
       ...request,
       context_id: this.contextId,
@@ -184,8 +191,14 @@ export class TTSWSContext {
    * Cancel this context to stop generating speech.
    */
   async cancel() {
-    await this._ws.cancelContext(this.contextId);
+    // Unregister first so receive() unblocks immediately, even if
+    // sending the cancel request to the server fails.
     this._ws._unregisterContext(this.contextId);
+    try {
+      await this._ws.cancelContext(this.contextId);
+    } catch {
+      // If the connection is dead, there's nothing to cancel server-side, so do nothing.
+    }
   }
 }
 
@@ -363,6 +376,11 @@ export class TTSWS extends TTSEmitter {
 
   /** Unregister a per-context queue. Called on context completion or cancellation. */
   _unregisterContext(contextId: string): void {
+    const entry = this._contextQueues.get(contextId);
+    if (entry?.resolve) {
+      entry.resolve();
+      entry.resolve = null;
+    }
     this._contextQueues.delete(contextId);
   }
 

--- a/tests/ws-routing.test.ts
+++ b/tests/ws-routing.test.ts
@@ -225,6 +225,61 @@ describe('WebSocket multi-context routing', () => {
     ws.close();
   });
 
+  test('cancel() while receive() is waiting unblocks receive()', async () => {
+    const ws = createTestWS();
+
+    const ctx = ws.context({ ...CONTEXT_OPTIONS, contextId: 'cancel-while-waiting' });
+
+    // Start receiving (will block waiting for events).
+    const events: WebsocketResponse[] = [];
+    const receivePromise = (async () => {
+      for await (const event of ctx.receive()) {
+        events.push(event);
+      }
+    })();
+
+    // Give receive() a tick to start waiting.
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    // Cancel should unblock receive().
+    await ctx.cancel();
+
+    // receive() should complete without hanging.
+    await receivePromise;
+
+    expect(events.length).toBe(0);
+    expect(ws._getContextQueue('cancel-while-waiting')).toBeUndefined();
+
+    ws.close();
+  });
+
+  test('generate() unregisters context queue to avoid memory leak', async () => {
+    const ws = createTestWS();
+
+    const ctx = ws.context({ ...CONTEXT_OPTIONS, contextId: 'gen-leak-test' });
+    expect(ws._getContextQueue('gen-leak-test')).toBeDefined();
+
+    // Calling generate() should immediately unregister the per-context queue
+    // so events don't accumulate in both the queue and generate()'s local buffer.
+    // We just need to start the generator to trigger the unregister — we don't
+    // need to actually consume it (that would require a live connection).
+    const gen = ctx.generate({
+      model_id: 'sonic-3',
+      voice: { mode: 'id', id: 'test-voice' },
+      output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 as const },
+      transcript: 'test',
+    });
+
+    // Advance the generator to the first yield point (triggers unregister).
+    // It will hang on send() since there's no connection, so race with a timeout.
+    const step = Promise.race([gen.next(), new Promise<void>((r) => setTimeout(r, 50))]);
+    await step;
+
+    expect(ws._getContextQueue('gen-leak-test')).toBeUndefined();
+
+    ws.close();
+  });
+
   test('receive() with timeout throws WebSocketTimeoutError', async () => {
     const ws = createTestWS();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core request/response plumbing and TTS WebSocket behavior (routing, reconnects, timeouts), which can affect many API calls and streaming use cases. Changes are mostly additive/bug-fix oriented but could introduce subtle regressions in streaming or request encoding.
> 
> **Overview**
> **TTS streaming contexts are reworked** to use per-`context_id` queues so events are buffered and correctly routed across concurrent contexts, with new `flush()`, optional receive timeouts (`WebSocketTimeoutError`), safer `cancel()`, and transparent reconnect-on-send behavior.
> 
> **Infill and binary audio handling are consolidated** by removing the standalone `Infill` resource and exposing `POST /infill/bytes` as `client.tts.infill()` returning a `Response`; `voiceChanger.changeVoiceBytes()` now also returns a binary `Response`. WebSocket response types are expanded/normalized to include additional wire fields (e.g. `data`, `flush_id`, timestamps payloads).
> 
> **Client robustness updates**: query stringification is centralized (`internal/utils/query`), list/request helpers accept async options, `application/x-www-form-urlencoded` bodies are encoded via query stringification, JSON parsing returns `undefined` on `content-length: 0`, and abort handling avoids leaking request option closures. Docs/examples/CI are updated accordingly (pnpm bump, new examples, removed prism mock bootstrapping in tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fee7cd1ed1230248e4c3390f711d88eb868926f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->