### PR TITLE
Backcompat typing consistency

### DIFF
--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -13,14 +13,6 @@ import Cartesia, {
   BadRequestError,
   AuthenticationError,
 } from '@cartesia/cartesia-js';
-import type { WebsocketResponse } from '@cartesia/cartesia-js/resources/tts/tts';
-
-// The generated WebsocketResponse types don't include all wire fields (e.g. `data`
-// on chunks, `word_timestamps` on timestamps). We use a small helper to access them.
-function chunkData(event: WebsocketResponse): Buffer | null {
-  const data = (event as any).data as string | undefined;
-  return data ? Buffer.from(data, 'base64') : null;
-}
 
 // =============================================================================
 // Client Initialization
@@ -68,8 +60,7 @@ async function ttsWebsocketBasic(client: Cartesia): Promise<void> {
     output_format: { container: 'raw', encoding: 'pcm_f32le', sample_rate: 44100 },
   })) {
     if (event.type === 'chunk') {
-      const audio = chunkData(event);
-      if (audio) file.write(audio);
+      if (event.audio) file.write(event.audio);
     }
   }
 
@@ -100,8 +91,7 @@ async function ttsWebsocketContinuations(client: Cartesia): Promise<void> {
 
   for await (const event of ctx.receive()) {
     if (event.type === 'chunk') {
-      const audio = chunkData(event);
-      if (audio) file.write(audio);
+      if (event.audio) file.write(event.audio);
     }
   }
 
@@ -145,16 +135,13 @@ async function ttsWebsocketFlushing(client: Cartesia): Promise<void> {
     if (loggable.data) loggable.data = '[...]';
     console.log('Event:', JSON.stringify(loggable));
 
-    if (event.type === 'chunk') {
-      const audio = chunkData(event);
-      if (audio) {
-        const flushId = (event as any).flush_id ?? 0;
-        if (!files.has(flushId)) {
-          const name = `tts_flush_${flushId}_${ts}.pcm`;
-          files.set(flushId, fs.createWriteStream(name));
-        }
-        files.get(flushId)!.write(audio);
+    if (event.type === 'chunk' && event.audio) {
+      const flushId = (event as any).flush_id ?? 0;
+      if (!files.has(flushId)) {
+        const name = `tts_flush_${flushId}_${ts}.pcm`;
+        files.set(flushId, fs.createWriteStream(name));
       }
+      files.get(flushId)!.write(event.audio);
     }
   }
 
@@ -198,8 +185,7 @@ async function ttsWebsocketEmotion(client: Cartesia): Promise<void> {
 
   for await (const event of ctx.receive()) {
     if (event.type === 'chunk') {
-      const audio = chunkData(event);
-      if (audio) file.write(audio);
+      if (event.audio) file.write(event.audio);
     }
   }
 
@@ -240,8 +226,7 @@ async function ttsWebsocketSpeed(client: Cartesia): Promise<void> {
 
   for await (const event of ctx.receive()) {
     if (event.type === 'chunk') {
-      const audio = chunkData(event);
-      if (audio) file.write(audio);
+      if (event.audio) file.write(event.audio);
     }
   }
 
@@ -290,9 +275,8 @@ async function ttsWebsocketConcurrentContexts(client: Cartesia): Promise<void> {
   async function collect(ctx: { receive: typeof ctx1.receive }, filename: string): Promise<void> {
     const file = fs.createWriteStream(filename);
     for await (const event of ctx.receive()) {
-      if (event.type === 'chunk') {
-        const audio = chunkData(event);
-        if (audio) file.write(audio);
+      if (event.type === 'chunk' && event.audio) {
+        file.write(event.audio);
       }
     }
     file.end();
@@ -327,8 +311,7 @@ async function ttsWebsocketResponseHandling(client: Cartesia): Promise<void> {
     add_timestamps: true,
   })) {
     if (event.type === 'chunk') {
-      const audio = chunkData(event);
-      if (audio) file.write(audio);
+      if (event.audio) file.write(event.audio);
     } else if (event.type === 'timestamps') {
       const wt = (event as any).word_timestamps;
       if (wt) {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "lint": "./scripts/lint",
     "fix": "./scripts/format"
   },
-  "dependencies": {
-    "human-id": "^4.1.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.0",
     "@swc/core": "^1.3.102",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      human-id:
-        specifier: ^4.1.3
-        version: 4.1.3
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.0
@@ -1144,10 +1140,6 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-
-  human-id@4.1.3:
-    resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
-    hasBin: true
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -3271,8 +3263,6 @@ snapshots:
   highlight.js@10.7.3: {}
 
   html-escaper@2.0.2: {}
-
-  human-id@4.1.3: {}
 
   human-signals@2.1.0: {}
 

--- a/src/backcompat/errors.ts
+++ b/src/backcompat/errors.ts
@@ -1,5 +1,3 @@
-import { APIConnectionTimeoutError, APIError } from '../core/error';
-
 /** @deprecated Use {@link CartesiaError} or specialized error classes from core/error instead. */
 export class CartesiaClientError extends Error {
   readonly statusCode?: number;
@@ -22,23 +20,5 @@ export class CartesiaTimeoutError extends Error {
   constructor(message: string) {
     super(message);
     Object.setPrototypeOf(this, CartesiaTimeoutError.prototype);
-  }
-}
-
-export async function wrap<T>(promise: Promise<T>): Promise<T> {
-  try {
-    return await promise;
-  } catch (e) {
-    if (e instanceof APIConnectionTimeoutError) {
-      throw new CartesiaTimeoutError(e.message);
-    }
-    if (e instanceof APIError) {
-      throw new CartesiaClientError({
-        message: e.message,
-        statusCode: e.status,
-        body: e.error,
-      });
-    }
-    throw e;
   }
 }

--- a/src/backcompat/index.ts
+++ b/src/backcompat/index.ts
@@ -83,3 +83,4 @@ export * from './voices-wrapper';
 export * from './voice-changer-wrapper';
 export * from './types';
 export * from './errors';
+export * from './utils';

--- a/src/backcompat/tts-wrapper.ts
+++ b/src/backcompat/tts-wrapper.ts
@@ -1,7 +1,7 @@
 import WebSocket from 'ws';
 import { Cartesia } from '../client';
 import { BackCompatRequestOptions } from './types';
-import { wrap } from './errors';
+import { wrap } from './utils';
 import { Readable } from 'stream';
 
 // Define compatible interfaces to match the old SDK types for WebSocket

--- a/src/backcompat/utils.ts
+++ b/src/backcompat/utils.ts
@@ -1,0 +1,34 @@
+import { APIConnectionTimeoutError, APIError } from '../core/error';
+import { CartesiaClientError, CartesiaTimeoutError } from './errors';
+
+/** Convert snake_case keys to camelCase, recursively. Only transforms plain objects. */
+export function snakeToCamel(obj: any): any {
+  if (Array.isArray(obj)) return obj.map(snakeToCamel);
+  if (obj !== null && typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype) {
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      const camelKey = key.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+      result[camelKey] = snakeToCamel(value);
+    }
+    return result;
+  }
+  return obj;
+}
+
+export async function wrap<T, R = T>(promise: Promise<T>): Promise<R> {
+  try {
+    return snakeToCamel(await promise);
+  } catch (e) {
+    if (e instanceof APIConnectionTimeoutError) {
+      throw new CartesiaTimeoutError(e.message);
+    }
+    if (e instanceof APIError) {
+      throw new CartesiaClientError({
+        message: e.message,
+        statusCode: e.status,
+        body: e.error,
+      });
+    }
+    throw e;
+  }
+}

--- a/src/backcompat/voice-changer-wrapper.ts
+++ b/src/backcompat/voice-changer-wrapper.ts
@@ -4,7 +4,7 @@ import { type Uploadable } from '../core/uploads';
 import { type RequestOptions as InternalRequestOptions } from '../internal/request-options';
 import { Readable } from 'stream';
 import { BackCompatRequestOptions } from './types';
-import { wrap } from './errors';
+import { wrap } from './utils';
 
 export interface BackCompatVoiceChangerBytesRequest {
   voiceId: string;

--- a/src/backcompat/voices-wrapper.ts
+++ b/src/backcompat/voices-wrapper.ts
@@ -3,16 +3,37 @@ import { Cartesia } from '../client';
 import { type Uploadable } from '../core/uploads';
 import {
   type VoiceCloneParams,
-  type VoiceMetadata,
   type SupportedLanguage,
+  type GenderPresentation,
   type VoiceUpdateParams,
-  type Voice,
   type VoiceLocalizeParams,
   type VoiceListParams,
 } from '../resources/voices';
 import { type RequestOptions as InternalRequestOptions } from '../internal/request-options';
 import { BackCompatRequestOptions } from './types';
-import { wrap } from './errors';
+import { wrap, snakeToCamel } from './utils';
+
+export interface BackCompatVoice {
+  id: string;
+  createdAt: string;
+  description: string;
+  isOwner: boolean;
+  isPublic: boolean;
+  language: SupportedLanguage;
+  name: string;
+  gender?: GenderPresentation | null;
+  previewFileUrl?: string | null;
+}
+
+export interface BackCompatVoiceMetadata {
+  id: string;
+  createdAt: string;
+  description: string;
+  isPublic: boolean;
+  language: SupportedLanguage;
+  name: string;
+  userId: string;
+}
 
 export interface BackCompatVoiceListOptions {
   gender?: 'masculine' | 'feminine' | 'gender_neutral' | null;
@@ -73,7 +94,7 @@ export class VoicesWrapper {
     clip: File | fs.ReadStream | Blob,
     request: BackCompatCloneVoiceRequest,
     requestOptions?: BackCompatRequestOptions,
-  ): Promise<VoiceMetadata> {
+  ): Promise<BackCompatVoiceMetadata> {
     const params: VoiceCloneParams = {
       clip: clip as Uploadable,
       name: request.name,
@@ -99,7 +120,7 @@ export class VoicesWrapper {
       options.signal = requestOptions.abortSignal;
     }
 
-    return wrap(this.client.voices.clone(params, options));
+    return wrap<any, BackCompatVoiceMetadata>(this.client.voices.clone(params, options));
   }
 
   /** @deprecated Use {@link Cartesia.voices.update} instead. */
@@ -107,7 +128,7 @@ export class VoicesWrapper {
     id: string,
     request: BackCompatUpdateVoiceRequest,
     requestOptions?: BackCompatRequestOptions,
-  ): Promise<Voice> {
+  ): Promise<BackCompatVoice> {
     const params: VoiceUpdateParams = {
       name: request.name,
       description: request.description,
@@ -125,14 +146,14 @@ export class VoicesWrapper {
       options.signal = requestOptions.abortSignal;
     }
 
-    return wrap(this.client.voices.update(id, params, options));
+    return wrap<any, BackCompatVoice>(this.client.voices.update(id, params, options));
   }
 
   /** @deprecated Use {@link Cartesia.voices.localize} instead. */
   async localize(
     request: BackCompatLocalizeVoiceRequest,
     requestOptions?: BackCompatRequestOptions,
-  ): Promise<VoiceMetadata> {
+  ): Promise<BackCompatVoiceMetadata> {
     const params: VoiceLocalizeParams = {
       voice_id: request.voiceId,
       name: request.name,
@@ -157,11 +178,11 @@ export class VoicesWrapper {
       options.signal = requestOptions.abortSignal;
     }
 
-    return wrap(this.client.voices.localize(params, options));
+    return wrap<any, BackCompatVoiceMetadata>(this.client.voices.localize(params, options));
   }
 
   /** @deprecated Use {@link Cartesia.voices.get} instead. */
-  async get(id: string, requestOptions?: BackCompatRequestOptions): Promise<Voice> {
+  async get(id: string, requestOptions?: BackCompatRequestOptions): Promise<BackCompatVoice> {
     const options: InternalRequestOptions = {};
     if (requestOptions) {
       if (requestOptions.timeoutInSeconds) {
@@ -174,14 +195,14 @@ export class VoicesWrapper {
       options.signal = requestOptions.abortSignal;
     }
 
-    return wrap(this.client.voices.get(id, {}, options));
+    return wrap<any, BackCompatVoice>(this.client.voices.get(id, {}, options));
   }
 
   /** @deprecated Use {@link Cartesia.voices.list} instead. */
   async list(
     listOptions?: BackCompatVoiceListOptions,
     requestOptions?: BackCompatRequestOptions,
-  ): Promise<Voice[]> {
+  ): Promise<BackCompatVoice[]> {
     const params: VoiceListParams = {};
     if (listOptions) {
       if (listOptions.gender !== undefined) params.gender = listOptions.gender;
@@ -204,9 +225,9 @@ export class VoicesWrapper {
     }
 
     // The new SDK returns a paginated result, we collect all pages
-    const voices: Voice[] = [];
+    const voices: BackCompatVoice[] = [];
     for await (const voice of this.client.voices.list(params, options)) {
-      voices.push(voice);
+      voices.push(snakeToCamel(voice) as BackCompatVoice);
     }
     return voices;
   }

--- a/src/resources/tts/tts.ts
+++ b/src/resources/tts/tts.ts
@@ -339,6 +339,11 @@ export namespace WebsocketResponse {
   export interface Chunk {
     data: string;
 
+    /** Decoded audio data as a Buffer. Base64-decodes `data`. Set by the SDK on receipt. 
+     * NB: this is a manually-added helper, not auto-generated.
+     */
+    audio: Buffer | null;
+
     done: boolean;
 
     status_code: number;

--- a/src/resources/tts/ws.ts
+++ b/src/resources/tts/ws.ts
@@ -245,6 +245,12 @@ export class TTSWS extends TTSEmitter {
       })();
 
       if (event) {
+        // Decode audio for chunk events (mirrors Python SDK's .audio property).
+        if (event.type === 'chunk') {
+          const chunk = event as TTSAPI.WebsocketResponse.Chunk;
+          chunk.audio = chunk.data ? Buffer.from(chunk.data, 'base64') : null;
+        }
+
         // Always emit on EventEmitter for backwards compatibility and global listeners.
         this._emit('event', event);
 

--- a/src/resources/tts/ws.ts
+++ b/src/resources/tts/ws.ts
@@ -1,7 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import * as WS from 'ws';
-import { humanId } from 'human-id';
+import { uuid4 } from '../../internal/utils/uuid';
 import { TTSEmitter, WebSocketTimeoutError, buildURL } from './internal-base';
 import * as TTSAPI from './tts';
 import type { Cartesia } from '../../client';
@@ -45,7 +45,7 @@ export class TTSWSContext {
       output_format: options.output_format,
     };
     this._timeout = options.timeout;
-    this.contextId = options.contextId ?? humanId({ separator: '-', capitalize: false });
+    this.contextId = options.contextId ?? uuid4();
   }
 
   /**
@@ -292,7 +292,8 @@ export class TTSWS extends TTSEmitter {
    * Send a generation request and iterate over the responses.
    */
   async *generate(request: TTSAPI.GenerationRequest): AsyncGenerator<TTSAPI.WebsocketResponse> {
-    const contextId = request.context_id;
+    const contextId = request.context_id ?? uuid4();
+    request = { ...request, context_id: contextId };
     const queue: TTSAPI.WebsocketResponse[] = [];
     let done = false;
     let error: Error | null = null;


### PR DESCRIPTION
- Adds .audio parsing chunk helper
- keeps type shapes consistent for backcompat return values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public SDK surface for TTS WebSocket events (adds `chunk.audio`, auto-assigns `context_id`) and changes backcompat wrappers to camel-case/retarget return types, which could affect downstream typing and expectations.
> 
> **Overview**
> Adds a first-class `audio: Buffer | null` helper on TTS WebSocket `chunk` events by decoding base64 `data` inside `TTSWS`, and updates examples to write `event.audio` directly.
> 
> Replaces `human-id` context identifiers with `uuid4()` and ensures `generate()` always sends a `context_id` when omitted, then removes the `human-id` dependency.
> 
> Refactors the backcompat layer by moving `wrap()` into a new `utils.ts`, adding recursive `snakeToCamel` conversion, exporting these utilities, and updating voice wrappers to return explicit backcompat types with consistent camelCased fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 321cc4de4833d6d007c5b9a1b78cf592fbc5ec6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->