### PR TITLE
fix(backcompat): throw a useful error when CartesiaClient is used in the browser

### DIFF
--- a/src/backcompat/tts-wrapper.ts
+++ b/src/backcompat/tts-wrapper.ts
@@ -7,12 +7,11 @@ import type { RequestOptions } from '../internal/request-options';
 import { CartesiaError } from '../error';
 import { uuid4 } from '../internal/utils/uuid';
 
-let _ws: typeof import('ws') | undefined;
+let _ws: Partial<typeof import('ws')> | undefined;
 try {
   _ws = require('ws');
 } catch {
   // Optional — in browsers, we use the native WebSocket API instead.
-  _ws = undefined;
 }
 
 // Define compatible interfaces to match the old SDK types for WebSocket
@@ -159,7 +158,7 @@ export class WebSocketWrapper {
   }
 
   async connect() {
-    if (_ws === undefined) {
+    if (_ws?.WebSocket === undefined) {
       throw new CartesiaError(
         'The "ws" peer dependency is required for WebSocket support in Node.js. If you are using CartesiaClient from a browser, switch to `import Cartesia from "@carteisa/cartesia-js"` for the browser-compatible client.',
       );


### PR DESCRIPTION
Some browser bundles will not throw an error on `_ws = require('ws')`. Instead, `_ws` becomes a function.

This change adjusts the type and runtime check to match fix(browsers): check if ws.WebSocket is undefined for browser compatibility ([b04cbbc](https://github.com/cartesia-ai/cartesia-js/commit/b04cbbc9e5af4f9568f674a9b15c2d68130021d1)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small runtime/type guard in deprecated backcompat WebSocket connect; no auth or API contract changes.
> 
> **Overview**
> Back-compat **`WebSocketWrapper.connect()`** now treats Node WebSocket support as “`ws.WebSocket` exists,” not “`require('ws')` didn’t throw.” The `_ws` shim is typed as **`Partial<typeof import('ws')>`** and **`connect()`** throws the existing **`CartesiaError`** (with the browser import hint) when **`_ws?.WebSocket`** is missing.
> 
> This mirrors the browser-safe check already used in the main TTS WebSocket client, so browser bundles that stub **`require('ws')`** without a real **`WebSocket`** constructor fail fast instead of failing later at **`new _ws.WebSocket(...)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f159999db1d18e7d48be8f10cead2bf38f34145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->