### PR TITLE
docs: update contributing.md with publish-npm-trusted.yml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ the changes aren't made through the automated pipeline, you may want to make rel
 
 ### Publish with a GitHub workflow
 
-You can release to package managers by using [the `Publish NPM` GitHub action](https://www.github.com/cartesia-ai/cartesia-js/actions/workflows/publish-npm.yml). This requires a setup organization or repository secret to be set up.
+You can release to package managers by using [the `Publish NPM` GitHub action](https://www.github.com/cartesia-ai/cartesia-js/actions/workflows/publish-npm-trusted.yml).
 
 ### Publish manually
 


### PR DESCRIPTION
I deleted `publish-npm.yml` after relasing v3.1.0 since my npm token expired. This project now uses `publish-npm-trusted.yml`, which doesn't require an npm token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and wording change with no runtime or release-script behavior in this diff.
> 
> **Overview**
> Updates **CONTRIBUTING.md** so manual NPM releases via GitHub Actions point at **`publish-npm-trusted.yml`** instead of the removed **`publish-npm.yml`**.
> 
> The doc no longer says an organization or repository **NPM_TOKEN** secret is required for that workflow path, matching the trusted publishing setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f5fda1189584e8cc4999c994a6f661ee94fea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->