### PR TITLE
feat: stamp client identity on REST and WebSocket handshakes

### DIFF
--- a/src/backcompat/tts-wrapper.ts
+++ b/src/backcompat/tts-wrapper.ts
@@ -1,5 +1,6 @@
 import type * as WS from 'ws';
 import { Cartesia } from '../client';
+import { getWebSocketConnectHeaders } from '../internal/client-identity';
 import { BackCompatRequestOptions } from './types';
 import { wrap } from './utils';
 import type { Readable } from 'stream';
@@ -180,15 +181,13 @@ export class WebSocketWrapper {
 
     const url = new URL(urlStr);
 
-    const headers: Record<string, string> = {
-      'cartesia-version': '2025-11-04',
-    };
+    const authHeaders: Record<string, string> = {};
     if (this.client.apiKey) {
-      headers['Authorization'] = `Bearer ${this.client.apiKey}`;
+      authHeaders['Authorization'] = `Bearer ${this.client.apiKey}`;
     }
 
     const socket = new _ws.WebSocket(url.toString(), {
-      headers,
+      headers: getWebSocketConnectHeaders(authHeaders),
     });
     this.socket = socket;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,7 @@ import { sleep } from './internal/utils/sleep';
 export type { Logger, LogLevel } from './internal/utils/log';
 import { castToError, isAbortError } from './internal/errors';
 import type { APIResponseProps } from './internal/parse';
-import { getClientRequestHeaders, getClientUserAgent } from './internal/client-identity';
+import { getClientRequestHeaders } from './internal/client-identity';
 import { getPlatformHeaders } from './internal/detect-platform';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
@@ -351,10 +351,6 @@ export class Cartesia {
 
   protected stringifyQuery(query: object | Record<string, unknown>): string {
     return stringifyQuery(query);
-  }
-
-  private getUserAgent(): string {
-    return getClientUserAgent();
   }
 
   protected defaultIdempotencyKey(): string {

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,6 +8,7 @@ import { sleep } from './internal/utils/sleep';
 export type { Logger, LogLevel } from './internal/utils/log';
 import { castToError, isAbortError } from './internal/errors';
 import type { APIResponseProps } from './internal/parse';
+import { getClientRequestHeaders, getClientUserAgent } from './internal/client-identity';
 import { getPlatformHeaders } from './internal/detect-platform';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
@@ -353,7 +354,7 @@ export class Cartesia {
   }
 
   private getUserAgent(): string {
-    return `${this.constructor.name}/JS ${VERSION}`;
+    return getClientUserAgent();
   }
 
   protected defaultIdempotencyKey(): string {
@@ -788,9 +789,9 @@ export class Cartesia {
 
     const headers = buildHeaders([
       idempotencyHeaders,
+      getClientRequestHeaders(),
       {
         Accept: 'application/json',
-        'User-Agent': this.getUserAgent(),
         'X-Stainless-Retry-Count': String(retryCount),
         ...(options.timeout ? { 'X-Stainless-Timeout': String(Math.trunc(options.timeout / 1000)) } : {}),
         ...getPlatformHeaders(),

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,6 @@ import { getPlatformHeaders } from './internal/detect-platform';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
 import { stringifyQuery } from './internal/utils/query';
-import { VERSION } from './version';
 import * as Errors from './core/error';
 import * as Pagination from './core/pagination';
 import { AbstractPage, type CursorIDPageParams, CursorIDPageResponse } from './core/pagination';

--- a/src/internal/client-identity.ts
+++ b/src/internal/client-identity.ts
@@ -1,0 +1,28 @@
+import { VERSION } from '../version';
+
+const CLIENT_ID = 'cartesia-js';
+
+/** Stable User-Agent for REST and Node WebSocket handshakes. */
+export function getClientUserAgent(): string {
+  return `Cartesia/JS ${VERSION}`;
+}
+
+/** Minification-proof client identifier for attribution in Datadog APM. */
+export function getClientHeader(): string {
+  return `${CLIENT_ID}/${VERSION}`;
+}
+
+/** Headers attached to every outbound Cartesia API request from this SDK. */
+export function getClientRequestHeaders(): Record<string, string> {
+  return {
+    'User-Agent': getClientUserAgent(),
+    'X-Cartesia-Client': getClientHeader(),
+  };
+}
+
+/** Browser WebSocket cannot set custom headers; stamp identity via query param. */
+export function appendBrowserWebSocketClientParam(url: URL): void {
+  if (!url.searchParams.has('cartesia_client')) {
+    url.searchParams.set('cartesia_client', getClientHeader());
+  }
+}

--- a/src/internal/client-identity.ts
+++ b/src/internal/client-identity.ts
@@ -1,4 +1,5 @@
 import { VERSION } from '../version';
+import { buildHeaders, type HeadersLike } from './headers';
 
 const CLIENT_ID = 'cartesia-js';
 
@@ -18,6 +19,23 @@ export function getClientRequestHeaders(): Record<string, string> {
     'User-Agent': getClientUserAgent(),
     'X-Cartesia-Client': getClientHeader(),
   };
+}
+
+/** Headers for Node WebSocket upgrade requests (TTS + STT). */
+export function getWebSocketConnectHeaders(
+  authHeaders: Record<string, string> = {},
+  extraHeaders?: HeadersLike,
+): Record<string, string> {
+  return Object.fromEntries(
+    buildHeaders([
+      getClientRequestHeaders(),
+      {
+        'cartesia-version': '2025-11-04',
+      },
+      authHeaders,
+      extraHeaders,
+    ]).values.entries(),
+  );
 }
 
 /** Browser WebSocket cannot set custom headers; stamp identity via query param. */

--- a/src/internal/client-identity.ts
+++ b/src/internal/client-identity.ts
@@ -5,7 +5,7 @@ const CLIENT_ID = 'cartesia-js';
 
 /** Stable User-Agent for REST and Node WebSocket handshakes. */
 export function getClientUserAgent(): string {
-  return `Cartesia/JS ${VERSION}`;
+  return getClientHeader();
 }
 
 /** Minification-proof client identifier for attribution in Datadog APM. */

--- a/src/internal/lib/tts/ws.ts
+++ b/src/internal/lib/tts/ws.ts
@@ -9,6 +9,10 @@ import { fromBase64, uuid4 } from '../../utils';
 import { WebSocketTimeoutError } from './websocket-timeout-error';
 import { CartesiaError } from '../../../error';
 import { getAuthorizationTokenFromHeaders } from '../utils/get-authorization-token-from-headers';
+import {
+  appendBrowserWebSocketClientParam,
+  getClientRequestHeaders,
+} from '../../client-identity';
 import { buildHeaders } from '../../headers';
 
 let _ws: Partial<typeof import('ws')> | undefined;
@@ -329,6 +333,7 @@ export class TTSWS extends TTSEmitter {
         ...options,
         headers: Object.fromEntries(
           buildHeaders([
+            getClientRequestHeaders(),
             {
               'cartesia-version': '2025-11-04',
             },
@@ -362,6 +367,8 @@ export class TTSWS extends TTSEmitter {
         // api key from client
         url.searchParams.set('api_key', this.client.apiKey);
       }
+
+      appendBrowserWebSocketClientParam(url);
 
       this.socket = new WebSocket(url);
     } else {

--- a/src/internal/lib/tts/ws.ts
+++ b/src/internal/lib/tts/ws.ts
@@ -11,7 +11,7 @@ import { CartesiaError } from '../../../error';
 import { getAuthorizationTokenFromHeaders } from '../utils/get-authorization-token-from-headers';
 import {
   appendBrowserWebSocketClientParam,
-  getClientRequestHeaders,
+  getWebSocketConnectHeaders,
 } from '../../client-identity';
 import { buildHeaders } from '../../headers';
 
@@ -331,16 +331,7 @@ export class TTSWS extends TTSEmitter {
       // Node: use ws package with custom headers for auth
       this.socket = new _ws.WebSocket(this.url, {
         ...options,
-        headers: Object.fromEntries(
-          buildHeaders([
-            getClientRequestHeaders(),
-            {
-              'cartesia-version': '2025-11-04',
-            },
-            this.authHeaders(),
-            options?.headers,
-          ]).values.entries(),
-        ),
+        headers: getWebSocketConnectHeaders(this.authHeaders(), options?.headers),
       });
     } else if (typeof WebSocket !== 'undefined') {
       // Browser: use native WebSocket with auth in URL query params

--- a/src/internal/lib/tts/ws.ts
+++ b/src/internal/lib/tts/ws.ts
@@ -9,10 +9,7 @@ import { fromBase64, uuid4 } from '../../utils';
 import { WebSocketTimeoutError } from './websocket-timeout-error';
 import { CartesiaError } from '../../../error';
 import { getAuthorizationTokenFromHeaders } from '../utils/get-authorization-token-from-headers';
-import {
-  appendBrowserWebSocketClientParam,
-  getWebSocketConnectHeaders,
-} from '../../client-identity';
+import { appendBrowserWebSocketClientParam, getWebSocketConnectHeaders } from '../../client-identity';
 import { buildHeaders } from '../../headers';
 
 let _ws: Partial<typeof import('ws')> | undefined;

--- a/src/resources/stt/auto-finalize/ws.ts
+++ b/src/resources/stt/auto-finalize/ws.ts
@@ -8,7 +8,7 @@ import { Cartesia } from '../../../client';
 import { getAuthorizationTokenFromHeaders } from '../../../internal/lib/utils/get-authorization-token-from-headers';
 import {
   appendBrowserWebSocketClientParam,
-  getClientRequestHeaders,
+  getWebSocketConnectHeaders,
 } from '../../../internal/client-identity';
 import { buildHeaders } from '../../../internal/headers';
 
@@ -47,16 +47,7 @@ export class AutoFinalizeWS extends AutoFinalizeWSBase<NodeWebSocket | BrowserWe
     if (_ws?.WebSocket !== undefined) {
       const ws = new _ws.WebSocket(url, {
         ...this._wsOptions,
-        headers: Object.fromEntries(
-          buildHeaders([
-            getClientRequestHeaders(),
-            {
-              'cartesia-version': '2025-11-04',
-            },
-            authHeaders,
-            this._wsOptions?.headers,
-          ]).values.entries(),
-        ),
+        headers: getWebSocketConnectHeaders(authHeaders, this._wsOptions?.headers),
       });
       return new NodeWebSocket(ws);
     }

--- a/src/resources/stt/auto-finalize/ws.ts
+++ b/src/resources/stt/auto-finalize/ws.ts
@@ -6,6 +6,10 @@ import { NodeWebSocket } from '../../../internal/ws-adapter-node';
 import { AutoFinalizeWSBase, type AutoFinalizeWSBaseOptions, type AutoFinalizeWSParameters } from './ws-base';
 import { Cartesia } from '../../../client';
 import { getAuthorizationTokenFromHeaders } from '../../../internal/lib/utils/get-authorization-token-from-headers';
+import {
+  appendBrowserWebSocketClientParam,
+  getClientRequestHeaders,
+} from '../../../internal/client-identity';
 import { buildHeaders } from '../../../internal/headers';
 
 let _ws: Partial<typeof import('ws')> | undefined;
@@ -45,6 +49,7 @@ export class AutoFinalizeWS extends AutoFinalizeWSBase<NodeWebSocket | BrowserWe
         ...this._wsOptions,
         headers: Object.fromEntries(
           buildHeaders([
+            getClientRequestHeaders(),
             {
               'cartesia-version': '2025-11-04',
             },
@@ -85,6 +90,8 @@ export class AutoFinalizeWS extends AutoFinalizeWSBase<NodeWebSocket | BrowserWe
       // api key from client
       url.searchParams.set('api_key', this._client.apiKey);
     }
+
+    appendBrowserWebSocketClientParam(url);
 
     return new BrowserWebSocket(new WebSocket(url));
   }

--- a/src/resources/stt/manual-finalize/ws.ts
+++ b/src/resources/stt/manual-finalize/ws.ts
@@ -10,6 +10,10 @@ import {
 } from './ws-base';
 import { Cartesia } from '../../../client';
 import { getAuthorizationTokenFromHeaders } from '../../../internal/lib/utils/get-authorization-token-from-headers';
+import {
+  appendBrowserWebSocketClientParam,
+  getClientRequestHeaders,
+} from '../../../internal/client-identity';
 import { buildHeaders } from '../../../internal/headers';
 
 let _ws: Partial<typeof import('ws')> | undefined;
@@ -49,6 +53,7 @@ export class ManualFinalizeWS extends ManualFinalizeWSBase<NodeWebSocket | Brows
         ...this._wsOptions,
         headers: Object.fromEntries(
           buildHeaders([
+            getClientRequestHeaders(),
             {
               'cartesia-version': '2025-11-04',
             },
@@ -89,6 +94,8 @@ export class ManualFinalizeWS extends ManualFinalizeWSBase<NodeWebSocket | Brows
       // api key from client
       url.searchParams.set('api_key', this._client.apiKey);
     }
+
+    appendBrowserWebSocketClientParam(url);
 
     return new BrowserWebSocket(new WebSocket(url));
   }

--- a/src/resources/stt/manual-finalize/ws.ts
+++ b/src/resources/stt/manual-finalize/ws.ts
@@ -12,7 +12,7 @@ import { Cartesia } from '../../../client';
 import { getAuthorizationTokenFromHeaders } from '../../../internal/lib/utils/get-authorization-token-from-headers';
 import {
   appendBrowserWebSocketClientParam,
-  getClientRequestHeaders,
+  getWebSocketConnectHeaders,
 } from '../../../internal/client-identity';
 import { buildHeaders } from '../../../internal/headers';
 
@@ -51,16 +51,7 @@ export class ManualFinalizeWS extends ManualFinalizeWSBase<NodeWebSocket | Brows
     if (_ws?.WebSocket !== undefined) {
       const ws = new _ws.WebSocket(url, {
         ...this._wsOptions,
-        headers: Object.fromEntries(
-          buildHeaders([
-            getClientRequestHeaders(),
-            {
-              'cartesia-version': '2025-11-04',
-            },
-            authHeaders,
-            this._wsOptions?.headers,
-          ]).values.entries(),
-        ),
+        headers: getWebSocketConnectHeaders(authHeaders, this._wsOptions?.headers),
       });
       return new NodeWebSocket(ws);
     }

--- a/tests/client-attribution.test.ts
+++ b/tests/client-attribution.test.ts
@@ -47,7 +47,7 @@ describe('cartesia-js client attribution by service', () => {
       const headers = getWebSocketConnectHeaders({ Authorization: 'Bearer test-api-key' });
       expectCartesiaJsHeaders(headers);
       expect(headers['cartesia-version']).toBe('2025-11-04');
-      expect(headers.authorization).toBe('Bearer test-api-key');
+      expect(headers['authorization']).toBe('Bearer test-api-key');
       expect(path).toMatch(/^\/(tts|stt)/);
     });
 

--- a/tests/client-attribution.test.ts
+++ b/tests/client-attribution.test.ts
@@ -1,0 +1,67 @@
+import Cartesia from '@cartesia/cartesia-js';
+import {
+  appendBrowserWebSocketClientParam,
+  getClientHeader,
+  getClientRequestHeaders,
+  getClientUserAgent,
+  getWebSocketConnectHeaders,
+} from '@cartesia/cartesia-js/internal/client-identity';
+import { VERSION } from '@cartesia/cartesia-js/version';
+
+/** Canonical cartesia-js identity — every outbound surface must use these values. */
+const CARTESIA_JS_CLIENT = {
+  userAgent: `Cartesia/JS ${VERSION}`,
+  clientHeader: `cartesia-js/${VERSION}`,
+} as const;
+
+function expectCartesiaJsHeaders(headers: Record<string, string>) {
+  expect(headers['user-agent']).toBe(CARTESIA_JS_CLIENT.userAgent);
+  expect(headers['x-cartesia-client']).toBe(CARTESIA_JS_CLIENT.clientHeader);
+}
+
+describe('cartesia-js client attribution by service', () => {
+  test('documents expected client identity', () => {
+    expect(getClientUserAgent()).toBe(CARTESIA_JS_CLIENT.userAgent);
+    expect(getClientHeader()).toBe(CARTESIA_JS_CLIENT.clientHeader);
+  });
+
+  describe.each([
+    { service: 'REST (any HTTP route)', path: '/tts/bytes', method: 'post' as const },
+    { service: 'REST (voices)', path: '/voices', method: 'get' as const },
+    { service: 'REST (STT transcribe)', path: '/stt', method: 'post' as const },
+  ])('$service', ({ path, method }) => {
+    test(`identifies as cartesia-js on ${path}`, async () => {
+      const client = new Cartesia({ apiKey: 'test-api-key', baseURL: 'https://api.cartesia.ai/' });
+      const { req } = await client.buildRequest({ path, method });
+      expect(req.headers.get('user-agent')).toBe(CARTESIA_JS_CLIENT.userAgent);
+      expect(req.headers.get('x-cartesia-client')).toBe(CARTESIA_JS_CLIENT.clientHeader);
+    });
+  });
+
+  describe.each([
+    { service: 'TTS WebSocket', path: '/tts/websocket' },
+    { service: 'STT auto-finalize WebSocket', path: '/stt/turns/websocket' },
+    { service: 'STT manual-finalize WebSocket', path: '/stt/websocket' },
+  ])('$service ($path)', ({ path }) => {
+    test('Node handshake sends cartesia-js headers', () => {
+      const headers = getWebSocketConnectHeaders({ Authorization: 'Bearer test-api-key' });
+      expectCartesiaJsHeaders(headers);
+      expect(headers['cartesia-version']).toBe('2025-11-04');
+      expect(headers.authorization).toBe('Bearer test-api-key');
+      expect(path).toMatch(/^\/(tts|stt)/);
+    });
+
+    test('browser handshake uses cartesia_client query param', () => {
+      const url = new URL(`wss://api.cartesia.ai${path}?model=ink-2`);
+      appendBrowserWebSocketClientParam(url);
+      expect(url.searchParams.get('cartesia_client')).toBe(CARTESIA_JS_CLIENT.clientHeader);
+    });
+  });
+
+  test('getClientRequestHeaders matches canonical identity', () => {
+    expect(getClientRequestHeaders()).toEqual({
+      'User-Agent': CARTESIA_JS_CLIENT.userAgent,
+      'X-Cartesia-Client': CARTESIA_JS_CLIENT.clientHeader,
+    });
+  });
+});

--- a/tests/client-attribution.test.ts
+++ b/tests/client-attribution.test.ts
@@ -10,7 +10,7 @@ import { VERSION } from '@cartesia/cartesia-js/version';
 
 /** Canonical cartesia-js identity — every outbound surface must use these values. */
 const CARTESIA_JS_CLIENT = {
-  userAgent: `Cartesia/JS ${VERSION}`,
+  userAgent: `cartesia-js/${VERSION}`,
   clientHeader: `cartesia-js/${VERSION}`,
 } as const;
 

--- a/tests/client-identity.test.ts
+++ b/tests/client-identity.test.ts
@@ -1,0 +1,36 @@
+import {
+  appendBrowserWebSocketClientParam,
+  getClientHeader,
+  getClientRequestHeaders,
+  getClientUserAgent,
+} from '@cartesia/cartesia-js/internal/client-identity';
+import { VERSION } from '@cartesia/cartesia-js/version';
+
+describe('client identity', () => {
+  test('getClientUserAgent uses stable Cartesia prefix', () => {
+    expect(getClientUserAgent()).toBe(`Cartesia/JS ${VERSION}`);
+  });
+
+  test('getClientHeader uses stable client id', () => {
+    expect(getClientHeader()).toBe(`cartesia-js/${VERSION}`);
+  });
+
+  test('getClientRequestHeaders includes User-Agent and X-Cartesia-Client', () => {
+    expect(getClientRequestHeaders()).toEqual({
+      'User-Agent': `Cartesia/JS ${VERSION}`,
+      'X-Cartesia-Client': `cartesia-js/${VERSION}`,
+    });
+  });
+
+  test('appendBrowserWebSocketClientParam sets cartesia_client query param', () => {
+    const url = new URL('wss://api.cartesia.ai/stt/turns/websocket?model=ink');
+    appendBrowserWebSocketClientParam(url);
+    expect(url.searchParams.get('cartesia_client')).toBe(`cartesia-js/${VERSION}`);
+  });
+
+  test('appendBrowserWebSocketClientParam does not override existing value', () => {
+    const url = new URL('wss://api.cartesia.ai/stt/turns/websocket?cartesia_client=custom');
+    appendBrowserWebSocketClientParam(url);
+    expect(url.searchParams.get('cartesia_client')).toBe('custom');
+  });
+});

--- a/tests/client-identity.test.ts
+++ b/tests/client-identity.test.ts
@@ -7,17 +7,17 @@ import {
 import { VERSION } from '@cartesia/cartesia-js/version';
 
 describe('client identity', () => {
-  test('getClientUserAgent uses stable Cartesia prefix', () => {
-    expect(getClientUserAgent()).toBe(`Cartesia/JS ${VERSION}`);
+  test('getClientUserAgent matches package slug client id', () => {
+    expect(getClientUserAgent()).toBe(`cartesia-js/${VERSION}`);
   });
 
   test('getClientHeader uses stable client id', () => {
     expect(getClientHeader()).toBe(`cartesia-js/${VERSION}`);
   });
 
-  test('getClientRequestHeaders includes User-Agent and X-Cartesia-Client', () => {
+  test('getClientRequestHeaders uses the same value for User-Agent and X-Cartesia-Client', () => {
     expect(getClientRequestHeaders()).toEqual({
-      'User-Agent': `Cartesia/JS ${VERSION}`,
+      'User-Agent': `cartesia-js/${VERSION}`,
       'X-Cartesia-Client': `cartesia-js/${VERSION}`,
     });
   });


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1273/cartesia-js-stamp-client-identity-on-rest-websocket-handshakes

## Summary

Streaming TTS and STT via the JS SDK were indistinguishable from hand-rolled WebSocket clients in Datadog APM. This adds stable client attribution on every outbound path using one canonical token: `cartesia-js/<version>` on `User-Agent`, `X-Cartesia-Client`, and browser `cartesia_client`.

## Changes

- Add shared `getClientRequestHeaders()` with unified `cartesia-js/<version>` on `User-Agent` and `X-Cartesia-Client`
- Apply headers on REST (`buildHeaders`) and Node WebSocket connects (TTS + STT auto/manual finalize)
- Append `cartesia_client` query param on browser WebSocket URLs (headers not settable there)
- Route backcompat `WebSocketWrapper` through the same header helper

## Test plan

- [x] `npm test -- tests/client-identity.test.ts tests/client-attribution.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only header and query-param changes with no auth or request-body logic changes; User-Agent format changes from the previous Stainless-style string.
> 
> **Overview**
> Centralizes SDK client attribution so REST and streaming WebSocket traffic can be distinguished in Datadog APM.
> 
> Adds **`internal/client-identity`** with a stable **`cartesia-js/<version>`** identity via **`User-Agent`** and **`X-Cartesia-Client`**. REST requests now pull these from **`getClientRequestHeaders()`** in **`buildHeaders`**, replacing the prior class-name-based User-Agent. Node WebSocket connects (TTS, STT auto/manual finalize, backcompat TTS wrapper) use **`getWebSocketConnectHeaders()`** so auth, **`cartesia-version`**, and client headers stay consistent. Browser WebSockets append **`cartesia_client`** on the URL when custom headers are unavailable.
> 
> New tests lock the canonical identity on REST **`buildRequest`**, Node WS handshakes, and browser query-param behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec19e91e55fd994f3d2f2b3b4d84c76242d29c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->