### PR TITLE
feat: export LocalizeTargetLanguage, Gender, LocalizeDialect, and Emotion

### DIFF
--- a/api.md
+++ b/api.md
@@ -193,6 +193,7 @@ Types:
 
 Types:
 
+- <code><a href="./src/resources/tts.ts">Emotion</a></code>
 - <code><a href="./src/resources/tts.ts">GenerationConfig</a></code>
 - <code><a href="./src/resources/tts.ts">GenerationRequest</a></code>
 - <code><a href="./src/resources/tts.ts">InfillModel</a></code>
@@ -229,7 +230,10 @@ Methods:
 
 Types:
 
+- <code><a href="./src/resources/voices.ts">Gender</a></code>
 - <code><a href="./src/resources/voices.ts">GenderPresentation</a></code>
+- <code><a href="./src/resources/voices.ts">LocalizeDialect</a></code>
+- <code><a href="./src/resources/voices.ts">LocalizeTargetLanguage</a></code>
 - <code><a href="./src/resources/voices.ts">SupportedLanguage</a></code>
 - <code><a href="./src/resources/voices.ts">Voice</a></code>
 - <code><a href="./src/resources/voices.ts">VoiceMetadata</a></code>

--- a/src/client.ts
+++ b/src/client.ts
@@ -42,6 +42,7 @@ import {
 } from './resources/pronunciation-dicts';
 import { Stt, SttTranscribeParams, SttTranscribeResponse } from './resources/stt';
 import {
+  Emotion,
   GenerationConfig,
   GenerationRequest,
   InfillModel,
@@ -71,7 +72,10 @@ import {
   VoiceChangerSSEEvent,
 } from './resources/voice-changer';
 import {
+  Gender,
   GenderPresentation,
+  LocalizeDialect,
+  LocalizeTargetLanguage,
   SupportedLanguage,
   Voice,
   VoiceCloneParams,
@@ -972,6 +976,7 @@ export declare namespace Cartesia {
 
   export {
     TTS as TTS,
+    type Emotion as Emotion,
     type GenerationConfig as GenerationConfig,
     type GenerationRequest as GenerationRequest,
     type InfillModel as InfillModel,
@@ -1003,7 +1008,10 @@ export declare namespace Cartesia {
 
   export {
     Voices as Voices,
+    type Gender as Gender,
     type GenderPresentation as GenderPresentation,
+    type LocalizeDialect as LocalizeDialect,
+    type LocalizeTargetLanguage as LocalizeTargetLanguage,
     type SupportedLanguage as SupportedLanguage,
     type Voice as Voice,
     type VoiceMetadata as VoiceMetadata,

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -47,6 +47,7 @@ export {
 } from './stt/stt';
 export {
   TTS,
+  type Emotion,
   type GenerationConfig,
   type GenerationRequest,
   type InfillModel,
@@ -76,7 +77,10 @@ export {
 } from './voice-changer';
 export {
   Voices,
+  type Gender,
   type GenderPresentation,
+  type LocalizeDialect,
+  type LocalizeTargetLanguage,
   type SupportedLanguage,
   type Voice,
   type VoiceMetadata,

--- a/src/resources/tts.ts
+++ b/src/resources/tts.ts
@@ -126,6 +126,73 @@ export class TTS extends APIResource {
 }
 
 /**
+ * Guide the emotion of the generated speech.
+ *
+ * The primary emotions are `neutral`, `calm`, `angry`, `content`, `sad`,
+ * `scared`. For more options, see
+ * [Volume, Speed, and Emotion](https://docs.cartesia.ai/build-with-cartesia/capability-guides/volume-speed-emotion#emotion-controls-beta).
+ */
+export type Emotion =
+  | 'neutral'
+  | 'happy'
+  | 'excited'
+  | 'enthusiastic'
+  | 'elated'
+  | 'euphoric'
+  | 'triumphant'
+  | 'amazed'
+  | 'surprised'
+  | 'flirtatious'
+  | 'curious'
+  | 'content'
+  | 'peaceful'
+  | 'serene'
+  | 'calm'
+  | 'grateful'
+  | 'affectionate'
+  | 'trust'
+  | 'sympathetic'
+  | 'anticipation'
+  | 'mysterious'
+  | 'angry'
+  | 'mad'
+  | 'outraged'
+  | 'frustrated'
+  | 'agitated'
+  | 'threatened'
+  | 'disgusted'
+  | 'contempt'
+  | 'envious'
+  | 'sarcastic'
+  | 'ironic'
+  | 'sad'
+  | 'dejected'
+  | 'melancholic'
+  | 'disappointed'
+  | 'hurt'
+  | 'guilty'
+  | 'bored'
+  | 'tired'
+  | 'rejected'
+  | 'nostalgic'
+  | 'wistful'
+  | 'apologetic'
+  | 'hesitant'
+  | 'insecure'
+  | 'confused'
+  | 'resigned'
+  | 'anxious'
+  | 'panicked'
+  | 'alarmed'
+  | 'scared'
+  | 'proud'
+  | 'confident'
+  | 'distant'
+  | 'skeptical'
+  | 'contemplative'
+  | 'determined';
+
+/**
  * Configure the various attributes of the generated speech. These are only for
  * `sonic-3` and have no effect on earlier models.
  *
@@ -137,65 +204,7 @@ export interface GenerationConfig {
   /**
    * Guide the emotion of the generated speech.
    */
-  emotion?:
-    | 'neutral'
-    | 'happy'
-    | 'excited'
-    | 'enthusiastic'
-    | 'elated'
-    | 'euphoric'
-    | 'triumphant'
-    | 'amazed'
-    | 'surprised'
-    | 'flirtatious'
-    | 'curious'
-    | 'content'
-    | 'peaceful'
-    | 'serene'
-    | 'calm'
-    | 'grateful'
-    | 'affectionate'
-    | 'trust'
-    | 'sympathetic'
-    | 'anticipation'
-    | 'mysterious'
-    | 'angry'
-    | 'mad'
-    | 'outraged'
-    | 'frustrated'
-    | 'agitated'
-    | 'threatened'
-    | 'disgusted'
-    | 'contempt'
-    | 'envious'
-    | 'sarcastic'
-    | 'ironic'
-    | 'sad'
-    | 'dejected'
-    | 'melancholic'
-    | 'disappointed'
-    | 'hurt'
-    | 'guilty'
-    | 'bored'
-    | 'tired'
-    | 'rejected'
-    | 'nostalgic'
-    | 'wistful'
-    | 'apologetic'
-    | 'hesitant'
-    | 'insecure'
-    | 'confused'
-    | 'resigned'
-    | 'anxious'
-    | 'panicked'
-    | 'alarmed'
-    | 'scared'
-    | 'proud'
-    | 'confident'
-    | 'distant'
-    | 'skeptical'
-    | 'contemplative'
-    | 'determined';
+  emotion?: Emotion;
 
   /**
    * Adjust the speed of the generated speech between 0.6x and 1.5x the original
@@ -988,6 +997,7 @@ export type WordTimestamps = Shared.WordTimestamps;
 
 export declare namespace TTS {
   export {
+    type Emotion as Emotion,
     type GenerationConfig as GenerationConfig,
     type GenerationRequest as GenerationRequest,
     type InfillModel as InfillModel,

--- a/src/resources/tts/index.ts
+++ b/src/resources/tts/index.ts
@@ -15,6 +15,7 @@
 
 export {
   TTS,
+  type Emotion,
   type GenerationConfig,
   type GenerationRequest,
   type ModelSpeed,

--- a/src/resources/voices.ts
+++ b/src/resources/voices.ts
@@ -133,6 +133,47 @@ export type VoicesCursorIDPage = CursorIDPage<Voice>;
 export type GenderPresentation = 'masculine' | 'feminine' | 'gender_neutral';
 
 /**
+ * Speaker gender for voice localization (`original_speaker_gender`).
+ */
+export type Gender = 'male' | 'female';
+
+/**
+ * Target language to localize a voice to. Distinct from TTS SupportedLanguage.
+ *
+ * Options: English (en), German (de), Spanish (es), French (fr), Japanese (ja),
+ * Portuguese (pt), Chinese (zh), Hindi (hi), Italian (it), Korean (ko), Dutch
+ * (nl), Polish (pl), Russian (ru), Swedish (sv), Turkish (tr), Arabic (ar),
+ * Hebrew (he), Tamil (ta), Telugu (te), Thai (th).
+ */
+export type LocalizeTargetLanguage =
+  | 'en'
+  | 'de'
+  | 'es'
+  | 'fr'
+  | 'ja'
+  | 'pt'
+  | 'zh'
+  | 'hi'
+  | 'it'
+  | 'ko'
+  | 'nl'
+  | 'pl'
+  | 'ru'
+  | 'sv'
+  | 'tr'
+  | 'ar'
+  | 'he'
+  | 'ta'
+  | 'te'
+  | 'th';
+
+/**
+ * Dialect allowlist for voice localization. Only supported for English (`en`),
+ * Spanish (`es`), Portuguese (`pt`), and French (`fr`).
+ */
+export type LocalizeDialect = 'au' | 'in' | 'so' | 'uk' | 'us' | 'mx' | 'pe' | 'br' | 'eu' | 'ca';
+
+/**
  * The language that the given voice should speak the transcript in. For valid
  * options, see [Models](https://docs.cartesia.ai/build-with-cartesia/tts-models).
  */
@@ -360,36 +401,17 @@ export interface VoiceLocalizeParams {
    *
    * Options: English (en), German (de), Spanish (es), French (fr), Japanese (ja),
    * Portuguese (pt), Chinese (zh), Hindi (hi), Italian (it), Korean (ko), Dutch
-   * (nl), Polish (pl), Russian (ru), Swedish (sv), Turkish (tr).
+   * (nl), Polish (pl), Russian (ru), Swedish (sv), Turkish (tr), Arabic (ar),
+   * Hebrew (he), Tamil (ta), Telugu (te), Thai (th).
    */
-  language:
-    | 'en'
-    | 'de'
-    | 'es'
-    | 'fr'
-    | 'ja'
-    | 'pt'
-    | 'zh'
-    | 'hi'
-    | 'it'
-    | 'ko'
-    | 'nl'
-    | 'pl'
-    | 'ru'
-    | 'sv'
-    | 'tr'
-    | 'ar'
-    | 'he'
-    | 'ta'
-    | 'te'
-    | 'th';
+  language: LocalizeTargetLanguage;
 
   /**
    * The name of the new localized voice.
    */
   name: string;
 
-  original_speaker_gender: 'male' | 'female';
+  original_speaker_gender: Gender;
 
   /**
    * The ID of the voice to localize.
@@ -400,12 +422,15 @@ export interface VoiceLocalizeParams {
    * The dialect to localize to. Only supported for English (`en`), Spanish (`es`),
    * Portuguese (`pt`), and French (`fr`).
    */
-  dialect?: 'au' | 'in' | 'so' | 'uk' | 'us' | 'mx' | 'pe' | 'br' | 'eu' | 'ca' | null;
+  dialect?: LocalizeDialect | null;
 }
 
 export declare namespace Voices {
   export {
+    type Gender as Gender,
     type GenderPresentation as GenderPresentation,
+    type LocalizeDialect as LocalizeDialect,
+    type LocalizeTargetLanguage as LocalizeTargetLanguage,
     type SupportedLanguage as SupportedLanguage,
     type Voice as Voice,
     type VoiceMetadata as VoiceMetadata,


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1468/export-named-sdk-models-for-localize-enums-emotion

## Summary

Exports named types for localize allowlists and TTS emotion so clients can import them instead of inlined string unions. `LocalizeTargetLanguage` stays distinct from TTS `SupportedLanguage`.

Paired with the docs OpenAPI `x-stainless-model` change. This PR hand-applies the intended Stainless output so review/merge is not blocked on regen.

## Changes

- Add `Gender`, `LocalizeTargetLanguage`, `LocalizeDialect` on Voices; `Emotion` on TTS
- Reference them from `VoiceLocalizeParams` and `GenerationConfig`
- Re-export via resource index, client namespace, and `api.md`

## Test plan

- [ ] Types available as `Cartesia.LocalizeTargetLanguage` / `Cartesia.Emotion` etc.
- [ ] Existing build / typecheck passes
- [ ] Compare against Stainless regen after docs OpenAPI merge (should match)