### PR TITLE
Remove bundlephobia badge from JS SDK README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cartesia TypeScript API Library
 
-[![NPM version](<https://img.shields.io/npm/v/@cartesia/cartesia-js.svg?label=npm%20(stable)>)](https://npmjs.org/package/@cartesia/cartesia-js) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/@cartesia/cartesia-js)
+[![NPM version](<https://img.shields.io/npm/v/@cartesia/cartesia-js.svg?label=npm%20(stable)>)](https://npmjs.org/package/@cartesia/cartesia-js)
 
 This library provides convenient access to the Cartesia REST API from server-side TypeScript or JavaScript.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the broken Bundlephobia badge from the README header
- keep the npm version badge in place

## Testing
- not run (README-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cartesia-ai.slack.com/archives/C088MQFJCSK/p1788387935911589?thread_ts=1788387935.911589&cid=C088MQFJCSK)

<div><a href="https://cursor.com/agents/bc-3d6f4e14-4f16-5e07-b9bd-2d2532e63445?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d6f4e14-4f16-5e07-b9bd-2d2532e63445&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

